### PR TITLE
Added: Logger, LoggerA and Loggers

### DIFF
--- a/core/src/main/scala/loggerf/Logger.scala
+++ b/core/src/main/scala/loggerf/Logger.scala
@@ -1,0 +1,12 @@
+package loggerf
+
+/**
+ * @author Kevin Lee
+ * @since 2020-03-28
+ */
+trait Logger {
+  def debug(message: String): Unit
+  def info(message: String): Unit
+  def warn(message: String): Unit
+  def error(message: String): Unit
+}

--- a/core/src/main/scala/loggerf/LoggerA.scala
+++ b/core/src/main/scala/loggerf/LoggerA.scala
@@ -1,0 +1,54 @@
+package loggerf
+
+import cats._
+import cats.implicits._
+
+import just.effect.EffectConstructor
+
+trait LoggerA[F[_]] {
+
+  implicit val FE0: EffectConstructor[F]
+  implicit val FM0: Monad[F]
+
+  implicit val logger0: Logger
+
+  def debugA[A](fa: F[A])(a2String: A => String): F[A] =
+    FM0.flatMap(fa){ a =>
+      FE0.effect(logger0.debug(a2String(a))) *> FE0.effect(a)
+    }
+  def debug(message: F[String]): F[String] = debugA(message)(identity)
+
+  def infoA[A](fa: F[A])(a2String: A => String): F[A] =
+    FM0.flatMap(fa){ a =>
+      FE0.effect(logger0.info(a2String(a))) *> FE0.effect(a)
+    }
+  def info(message: F[String]): F[String] = infoA(message)(identity)
+
+  def warnA[A](fa: F[A])(a2String: A => String): F[A] =
+    FM0.flatMap(fa){ a =>
+      FE0.effect(logger0.warn(a2String(a))) *> FE0.effect(a)
+    }
+  def warn(message: F[String]): F[String] = warnA(message)(identity)
+
+  def errorA[A](fa: F[A])(a2String: A => String): F[A] =
+    FM0.flatMap(fa){ a =>
+      FE0.effect(logger0.error(a2String(a))) *> FE0.effect(a)
+    }
+  def error(message: F[String]): F[String] = errorA(message)(identity)
+}
+
+object LoggerA {
+  def apply[F[_] : LoggerA]: LoggerA[F] = implicitly[LoggerA[F]]
+
+  implicit def loggerA[F[_]](
+    implicit FE: EffectConstructor[F], FM: Monad[F], logger: Logger
+  ): LoggerA[F] =
+    new LoggerA[F] {
+
+      override implicit val FE0: EffectConstructor[F] = FE
+      override implicit val FM0: Monad[F] = FM
+
+      override val logger0: Logger = logger
+    }
+
+}

--- a/core/src/main/scala/loggerf/Loggers.scala
+++ b/core/src/main/scala/loggerf/Loggers.scala
@@ -1,0 +1,32 @@
+package loggerf
+
+import cats.Monad
+import just.effect.{EffectConstructor, Effectful}
+
+/**
+ * @author Kevin Lee
+ * @since 2020-03-25
+ */
+trait Loggers[F[_]] extends LoggerA[F]
+
+object Loggers {
+
+  def apply[F[_] : Loggers]: Loggers[F] = implicitly[Loggers[F]]
+
+  implicit def loggers[F[_]](implicit EF: EffectConstructor[F], EM: Monad[F], logger: Logger): Loggers[F] =
+    new LoggersF[F]
+
+  final class LoggersF[F[_] : EffectConstructor : Monad](
+    implicit FE: EffectConstructor[F], FM: Monad[F], logger: Logger
+  )
+    extends Loggers[F]
+    with LoggerA[F]
+    with Effectful {
+
+    override implicit val FE0: EffectConstructor[F] = FE
+    override implicit val FM0: Monad[F] = FM
+
+    override val logger0: Logger = logger
+  }
+
+}


### PR DESCRIPTION
# Added: `Logger`, `LoggerA` and `Loggers`
* `Logger`: a wrapper for any existing Logger libs (e.g. slf4j, log4j, etc.)
* `LoggerA`: A typeclass to log `F[A]`
* `Loggers`: A typeclass for `F[_]` (Currently it's the same as `LoggerA` but it will be a combination of other loggers)