### PR TITLE
logger-f v0.1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,8 +44,8 @@ ThisBuild / developers   := List(
 ThisBuild / homepage := Some(url("https://github.com/Kevin-Lee/logger-f"))
 ThisBuild / scmInfo :=
   Some(ScmInfo(
-    url("https://github.com/Kevin-Lee/logger-f")
-    , "git@github.com:Kevin-Lee/logger-f.git"
+    browseUrl = url("https://github.com/Kevin-Lee/logger-f")
+  , connection = "scm:git:git@github.com:Kevin-Lee/logger-f.git"
   ))
 
 def prefixedProjectName(name: String) = s"logger-f${if (name.isEmpty) "" else s"-$name"}"
@@ -66,13 +66,6 @@ def projectCommonSettings(id: String, projectName: ProjectName, file: File): Pro
   Project(id, file)
     .settings(
       name := prefixedProjectName(projectName.projectName)
-    , unmanagedSourceDirectories in Compile ++= {
-      val sharedSourceDir = baseDirectory.value / "src/main"
-      if (scalaVersion.value.startsWith("2.13") || scalaVersion.value.startsWith("2.12"))
-        Seq(sharedSourceDir / "scala-2.12_2.13")
-      else
-        Seq(sharedSourceDir / "scala-2.10_2.11")
-    }
     , resolvers ++= Seq(
       Resolver.sonatypeRepo("releases")
       , hedgehogRepo

--- a/changelogs/0.1.0.md
+++ b/changelogs/0.1.0.md
@@ -1,0 +1,18 @@
+## [0.1.0](https://github.com/Kevin-Lee/logger-f/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3A%22milestone1%22) - 2020-04-13
+
+## Done
+### Added
+* Log with log level (#22)
+  * `Log.log(F[A])(aToString)`
+  * `Log.log(F[Option[A]])(ifEmptyWithLogLevel, aToStringWithLogLevel)`
+  * `Log.log(F[Either[A, B]])(aToStringWithLogLevel, bToStringWithLogLevel)`
+  * `Log.log(OptionT[F, A])(ifEmptyWithLogLevel, aToStringWithLogLevel)`
+  * `Log.log(EitherT[F, A, B])(aToStringWithLogLevel, bToStringWithLogLevel)`
+
+The following ones are experimental and might be removed in the future.
+
+* LoggerA for `F[A]`
+* LoggerOption for `F[Option[A]]`
+* LoggerOptionT for `OptionT[F, A]`
+* LoggerEither for `F[Either[A, B]]`
+* LoggerEitherT for `EitherT[F, A, B]`


### PR DESCRIPTION
# `logger-f` v0.1.0

## Done
## [0.1.0](https://github.com/Kevin-Lee/logger-f/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3A%22milestone1%22) - 2020-04-13

## Done
### Added
* Log with log level (#22)
  * `Log.log(F[A])(aToString)`
  * `Log.log(F[Option[A]])(ifEmptyWithLogLevel, aToStringWithLogLevel)`
  * `Log.log(F[Either[A, B]])(aToStringWithLogLevel, bToStringWithLogLevel)`
  * `Log.log(OptionT[F, A])(ifEmptyWithLogLevel, aToStringWithLogLevel)`
  * `Log.log(EitherT[F, A, B])(aToStringWithLogLevel, bToStringWithLogLevel)`

The following ones are experimental and might be removed in the future.

* LoggerA for `F[A]`
* LoggerOption for `F[Option[A]]`
* LoggerOptionT for `OptionT[F, A]`
* LoggerEither for `F[Either[A, B]]`
* LoggerEitherT for `EitherT[F, A, B]`
