### PR TITLE
logger-f v0.2.0

### DIFF
--- a/changelogs/0.2.0.md
+++ b/changelogs/0.2.0.md
@@ -1,0 +1,5 @@
+## [0.2.0](https://github.com/Kevin-Lee/logger-f/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3A%22milestone2%22) - 2020-05-08
+
+## Done
+* Add `log()(ignore)` to skip logging (#50)
+* Upgrade Effectie to 0.4.0 (#55)

--- a/project/ProjectInfo.scala
+++ b/project/ProjectInfo.scala
@@ -4,7 +4,7 @@ object ProjectInfo {
 
   final case class ProjectName(projectName: String) extends AnyVal
 
-  val ProjectVersion: String = "0.1.0"
+  val ProjectVersion: String = "0.2.0"
 
   def commonWarts(scalaBinaryVersion: String): Seq[wartremover.Wart] = scalaBinaryVersion match {
     case "2.10" =>


### PR DESCRIPTION
# logger-f v0.2.0
## [0.2.0](https://github.com/Kevin-Lee/logger-f/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3A%22milestone2%22) - 2020-05-08

## Done
* Add `log()(ignore)` to skip logging (#50)
* Upgrade Effectie to 0.4.0 (#55)
