### PR TITLE
logger-f v0.4.0

### DIFF
--- a/changelogs/0.4.0.md
+++ b/changelogs/0.4.0.md
@@ -1,0 +1,7 @@
+## [0.4.0](https://github.com/Kevin-Lee/logger-f/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3A%22milestone4%22) - 2020-06-30
+
+## Added:
+* Add `loggerf.Logger` for sbt (#74)
+
+## Changed:
+* Replace `master` branch with `main` branch (#73)

--- a/project/ProjectInfo.scala
+++ b/project/ProjectInfo.scala
@@ -4,7 +4,7 @@ object ProjectInfo {
 
   final case class ProjectName(projectName: String) extends AnyVal
 
-  val ProjectVersion: String = "0.3.1"
+  val ProjectVersion: String = "0.4.0"
 
   def commonWarts(scalaBinaryVersion: String): Seq[wartremover.Wart] = scalaBinaryVersion match {
     case "2.10" =>


### PR DESCRIPTION
# logger-f v0.4.0

## [0.4.0](https://github.com/Kevin-Lee/logger-f/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3A%22milestone4%22) - 2020-06-30

## Added:
* Add `loggerf.Logger` for sbt (#74)

## Changed:
* Replace `master` branch with `main` branch (#73)
