### PR TITLE
Close #90 - Add a way to set an internal Logger when creating loggerf.logger.Logger

### DIFF
--- a/core/src/test/scala/loggerf/logger/LoggerForTesting.scala
+++ b/core/src/test/scala/loggerf/logger/LoggerForTesting.scala
@@ -1,30 +1,63 @@
 package loggerf.logger
 
+import loggerf.logger.LoggerForTesting.MessageKeeper
+
 /**
  * @author Kevin Lee
  * @since 2020-04-12
  */
-@SuppressWarnings(Array("org.wartremover.warts.Var"))
 final case class LoggerForTesting private (
-  private var debugMessages: Vector[String]
-, private var infoMessages: Vector[String]
-, private var warnMessages: Vector[String]
-, private var errorMessages: Vector[String]
+  logger: MessageKeeper
 ) extends Logger {
   override def debug(message: String): Unit =
-    debugMessages = debugMessages :+ message
+    logger.debugMessages = logger.debugMessages :+ message
 
   override def info(message: String): Unit =
-    infoMessages = infoMessages :+ message
+    logger.infoMessages = logger.infoMessages :+ message
 
   override def warn(message: String): Unit =
-    warnMessages = warnMessages :+ message
+    logger.warnMessages = logger.warnMessages :+ message
 
   override def error(message: String): Unit =
-    errorMessages = errorMessages :+ message
+    logger.errorMessages = logger.errorMessages :+ message
 }
 
 object LoggerForTesting {
+
+  @SuppressWarnings(Array("org.wartremover.warts.Var"))
+  final case class MessageKeeper(
+    private var _debugMessages: Vector[String],
+    private var _infoMessages: Vector[String],
+    private var _warnMessages: Vector[String],
+    private var _errorMessages: Vector[String]
+  ) {
+    def debugMessages: Vector[String] = _debugMessages
+    private[LoggerForTesting] def debugMessages_=(debugMessages: Vector[String]): Unit =
+      _debugMessages = debugMessages
+
+    def infoMessages: Vector[String] = _infoMessages
+    private[LoggerForTesting] def infoMessages_=(infoMessages: Vector[String]): Unit =
+      _infoMessages = infoMessages
+
+    def warnMessages: Vector[String] = _warnMessages
+    private[LoggerForTesting] def warnMessages_=(warnMessages: Vector[String]): Unit =
+      _warnMessages = warnMessages
+
+    def errorMessages: Vector[String] = _errorMessages
+    private[LoggerForTesting] def errorMessages_=(errorMessages: Vector[String]): Unit =
+      _errorMessages = errorMessages
+  }
+
+  def apply(
+    debugMessages: Vector[String],
+    infoMessages: Vector[String],
+    warnMessages: Vector[String],
+    errorMessages: Vector[String]
+  ): LoggerForTesting =
+    LoggerForTesting(MessageKeeper(debugMessages, infoMessages, warnMessages, errorMessages))
+
   def apply(): LoggerForTesting =
-    LoggerForTesting(Vector.empty, Vector.empty, Vector.empty, Vector.empty)
+    LoggerForTesting(
+      MessageKeeper(Vector.empty, Vector.empty, Vector.empty, Vector.empty)
+    )
 }

--- a/log4j/src/main/scala/loggerf/logger/Log4jLogger.scala
+++ b/log4j/src/main/scala/loggerf/logger/Log4jLogger.scala
@@ -2,7 +2,9 @@ package loggerf.logger
 
 import scala.reflect.ClassTag
 
-final class Log4jLogger(logger: org.apache.logging.log4j.Logger) extends Logger {
+final class Log4jLogger(
+  val logger: org.apache.logging.log4j.Logger
+) extends Logger {
 
   override def debug(message: String): Unit = logger.debug(message)
 
@@ -21,4 +23,6 @@ object Log4jLogger {
   def log4jLogger(name: String): Logger =
     new Log4jLogger(org.apache.logging.log4j.LogManager.getLogger(name))
 
+  def log4jLoggerWith(logger: org.apache.logging.log4j.Logger): Logger =
+    new Log4jLogger(logger)
 }

--- a/sbt-logging/src/main/scala/loggerf/logger/SbtLogger.scala
+++ b/sbt-logging/src/main/scala/loggerf/logger/SbtLogger.scala
@@ -1,14 +1,14 @@
 package loggerf.logger
 
-final class SbtLogger(val log: sbt.util.Logger) extends Logger {
+final class SbtLogger(val logger: sbt.util.Logger) extends Logger {
 
-  override def debug(message: String): Unit = log.debug(message)
+  override def debug(message: String): Unit = logger.debug(message)
 
-  override def info(message: String): Unit = log.info(message)
+  override def info(message: String): Unit = logger.info(message)
 
-  override def warn(message: String): Unit = log.warn(message)
+  override def warn(message: String): Unit = logger.warn(message)
 
-  override def error(message: String): Unit = log.error(message)
+  override def error(message: String): Unit = logger.error(message)
 }
 
 object SbtLogger {

--- a/slf4j/src/main/scala/loggerf/logger/Slf4JLogger.scala
+++ b/slf4j/src/main/scala/loggerf/logger/Slf4JLogger.scala
@@ -2,7 +2,7 @@ package loggerf.logger
 
 import scala.reflect.ClassTag
 
-final class Slf4JLogger(logger: org.slf4j.Logger) extends Logger {
+final class Slf4JLogger(val logger: org.slf4j.Logger) extends Logger {
 
   override def debug(message: String): Unit = logger.debug(message)
 
@@ -20,5 +20,8 @@ object Slf4JLogger {
 
   def slf4JLogger(name: String): Logger =
     new Slf4JLogger(org.slf4j.LoggerFactory.getLogger(name))
+
+  def slf4JLoggerWith(logger: org.slf4j.Logger): Logger =
+    new Slf4JLogger(logger)
 
 }


### PR DESCRIPTION
# Summary
Close #90 - Add a way to set an internal `Logger` when creating `loggerf.logger.Logger`
