### PR TITLE
logger-f v1.0.0

### DIFF
--- a/changelogs/1.0.0.md
+++ b/changelogs/1.0.0.md
@@ -1,0 +1,21 @@
+## [1.0.0](https://github.com/Kevin-Lee/logger-f/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3A%22milestone5%22) - 2020-08-01
+
+## Done
+* Upgrade [effectie](https://kevin-lee.github.io/effectie) to 1.1.0 (#84)
+* Simplify import (#88)
+  
+  The old logger-f requires to import classes like this.
+  ```scala
+  import loggerf.Logger
+  import loggerf.Slf4JLogger
+  import loggerf.cats.Log
+  import loggerf.cats.Log.LeveledMessage._
+  import loggerf.cats.Logful._
+  ```  
+  It looks unorganized and hard to find which ones to import. So it's been simplified to
+  ```scala
+  import loggerf.cats._
+  import loggerf.logger._
+  import loggerf.syntax._
+  ```
+* Add a way to set an internal Logger when creating loggerf.logger.Logger (#90)

--- a/project/ProjectInfo.scala
+++ b/project/ProjectInfo.scala
@@ -4,7 +4,7 @@ object ProjectInfo {
 
   final case class ProjectName(projectName: String) extends AnyVal
 
-  val ProjectVersion: String = "0.4.0"
+  val ProjectVersion: String = "1.0.0"
 
   def commonWarts(scalaBinaryVersion: String): Seq[wartremover.Wart] = scalaBinaryVersion match {
     case "2.10" =>


### PR DESCRIPTION
# logger-f v1.0.0
## [1.0.0](https://github.com/Kevin-Lee/logger-f/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3A%22milestone5%22) - 2020-08-01

## Done
* Upgrade [effectie](https://kevin-lee.github.io/effectie) to 1.1.0 (#84)
* Simplify import (#88)
  
  The old logger-f requires to import classes like this.
  ```scala
  import loggerf.Logger
  import loggerf.Slf4JLogger
  import loggerf.cats.Log
  import loggerf.cats.Log.LeveledMessage._
  import loggerf.cats.Logful._
  ```  
  It looks unorganized and hard to find which ones to import. So it's been simplified to
  ```scala
  import loggerf.cats._
  import loggerf.logger._
  import loggerf.syntax._
  ```
* Add a way to set an internal Logger when creating loggerf.logger.Logger (#90)