### PR TITLE
Added: 5 second delay has been added to each Maven Central sync

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,7 +133,13 @@ jobs:
           BINTRAY_PACKAGES="logger-f-core logger-f-slf4j logger-f-log4j logger-f-sbt-logging logger-f-cats-effect logger-f-scalaz-effect"
           for bintray_package in $BINTRAY_PACKAGES
           do
+            echo ""
             echo "bintray_package: $bintray_package"
             echo "Sync to Maven Central..."
-            curl --user $BINTRAY_USER:$BINTRAY_PASS -X POST "https://api.bintray.com/maven_central_sync/$BINTRAY_SUBJECT/$BINTRAY_REPO/$bintray_package/versions/$PROJECT_VERSION"
+            curl \
+              --user $BINTRAY_USER:$BINTRAY_PASS \
+              -X POST \
+              "https://api.bintray.com/maven_central_sync/$BINTRAY_SUBJECT/$BINTRAY_REPO/$bintray_package/versions/$PROJECT_VERSION"
+
+            sleep 5s
           done


### PR DESCRIPTION
# Summary
Added: 5 second delay has been added to each Maven Central sync to give the Sonatype repo some time to close staging