### PR TITLE
logger-f v1.2.0

### DIFF
--- a/changelogs/1.2.0.md
+++ b/changelogs/1.2.0.md
@@ -1,0 +1,5 @@
+## [1.2.0](https://github.com/Kevin-Lee/logger-f/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3A%22milestone7%22) - 2020-08-06
+
+## Done
+* Make logging methods in `Logger` lazy (#98)
+* Change `loggerf.logger.Logger` to something other than `Logger` (#100) - It's now `CanLog`.

--- a/project/ProjectInfo.scala
+++ b/project/ProjectInfo.scala
@@ -4,7 +4,7 @@ object ProjectInfo {
 
   final case class ProjectName(projectName: String) extends AnyVal
 
-  val ProjectVersion: String = "1.1.0"
+  val ProjectVersion: String = "1.2.0"
 
   def commonWarts(scalaBinaryVersion: String): Seq[wartremover.Wart] = scalaBinaryVersion match {
     case "2.10" =>


### PR DESCRIPTION
# logger-f v1.2.0
## [1.2.0](https://github.com/Kevin-Lee/logger-f/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3A%22milestone7%22) - 2020-08-06

## Done
* Make logging methods in `Logger` lazy (#98)
* Change `loggerf.logger.Logger` to something other than `Logger` (#100) - It's now `CanLog`.
