### PR TITLE
Fix #113 - Log4s support is missing in publish

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -356,6 +356,7 @@ lazy val loggerF = (project in file("."))
   .aggregate(
     core,
     slf4jLogger,
+    log4sLogger,
     log4jLogger,
     sbtLogging,
     catsEffect,


### PR DESCRIPTION
# Summary
Fix #113 - Log4s support is missing in publish