### PR TITLE
logger-f v1.3.1

### DIFF
--- a/changelogs/1.3.1.md
+++ b/changelogs/1.3.1.md
@@ -1,0 +1,4 @@
+## [1.3.1](https://github.com/Kevin-Lee/logger-f/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3A%22milestone9%22) - 2020-09-14
+
+## Fixed
+* Log4s support is missing in publish (#113)

--- a/project/ProjectInfo.scala
+++ b/project/ProjectInfo.scala
@@ -4,7 +4,7 @@ object ProjectInfo {
 
   final case class ProjectName(projectName: String) extends AnyVal
 
-  val ProjectVersion: String = "1.3.0"
+  val ProjectVersion: String = "1.3.1"
 
   def commonWarts(scalaBinaryVersion: String): Seq[wartremover.Wart] = scalaBinaryVersion match {
     case "2.10" =>


### PR DESCRIPTION
# logger-f v1.3.1
## [1.3.1](https://github.com/Kevin-Lee/logger-f/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3A%22milestone9%22) - 2020-09-14

## Fixed
* Log4s support is missing in publish (#113)
