### PR TITLE
Updated: maven_central_sync.sh to include logger-f-log4s when publishing to Maven

### DIFF
--- a/.github/workflows/maven_central_sync.sh
+++ b/.github/workflows/maven_central_sync.sh
@@ -12,7 +12,7 @@ if [ "${GITHUB_TAG:-}" != "" ]; then
   echo "PROJECT_VERSION: $PROJECT_VERSION"
   echo "BINTRAY_SUBJECT: $BINTRAY_SUBJECT"
   echo "   BINTRAY_REPO: $BINTRAY_REPO"
-  BINTRAY_PACKAGES="logger-f-core logger-f-slf4j logger-f-log4j logger-f-sbt-logging logger-f-cats-effect logger-f-scalaz-effect"
+  BINTRAY_PACKAGES="logger-f-core logger-f-slf4j logger-f-log4s logger-f-log4j logger-f-sbt-logging logger-f-cats-effect logger-f-scalaz-effect"
   for bintray_package in $BINTRAY_PACKAGES
   do
     echo ""


### PR DESCRIPTION
# Summary
Updated: `maven_central_sync.sh` to include `logger-f-log4s` when publishing to Maven