### PR TITLE
Close #138 - Support Dotty (Scala 3.0.0-M2)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
           - { name: "Scala 2", version: "2.11.12", binary-version: "2.11", java-version: "8" }
           - { name: "Scala 2", version: "2.12.12", binary-version: "2.12", java-version: "11" }
           - { name: "Scala 2", version: "2.13.3",  binary-version: "2.13", java-version: "11" }
-          - { name: "Scala 3", version: "3.0.0-M1",  binary-version: "3.0.0-M1", java-version: "11" }
+          - { name: "Scala 3", version: "3.0.0-M2",  binary-version: "3.0.0-M2", java-version: "11" }
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
           - { name: "Scala 2", version: "2.11.12", binary-version: "2.11", java-version: "8" }
           - { name: "Scala 2", version: "2.12.12", binary-version: "2.12", java-version: "11" }
           - { name: "Scala 2", version: "2.13.3",  binary-version: "2.13", java-version: "11" }
-          - { name: "Scala 3", version: "3.0.0-M1",  binary-version: "3.0.0-M1", java-version: "11" }
+          - { name: "Scala 3", version: "3.0.0-M2",  binary-version: "3.0.0-M2", java-version: "11" }
 
     steps:
       - uses: actions/checkout@v2

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import kevinlee.sbt.SbtCommon.crossVersionProps
 import just.semver.SemVer
 import SemVer.{Major, Minor}
 
-val DottyVersion = "3.0.0-M1"
+val DottyVersion = "3.0.0-M2"
 val ProjectScalaVersion = "2.13.3"
 
 val removeDottyIncompatible: ModuleID => Boolean =
@@ -41,7 +41,7 @@ lazy val slf4jApi: ModuleID = "org.slf4j" % "slf4j-api" % "1.7.30"
 lazy val logbackClassic: ModuleID =  "ch.qos.logback" % "logback-classic" % "1.2.3"
 
 lazy val log4sLib: ModuleID = "org.log4s" %% "log4s" % "1.9.0"
-lazy val log4sLibForScala3: ModuleID = "org.log4s" %% "log4s" % "1.10.0-M1"
+lazy val log4sLibForScala3: ModuleID = "org.log4s" %% "log4s" % "1.10.0-M3"
 
 lazy val log4jApi = "org.apache.logging.log4j" % "log4j-api" % "2.13.1"
 lazy val log4jCore = "org.apache.logging.log4j" % "log4j-core" % "2.13.1"
@@ -129,7 +129,7 @@ def libraryDependenciesPostProcess(
     libraries
 )
 
-val effectieVersion: String = "1.6.0"
+val effectieVersion: String = "1.7.0"
 lazy val effectieCatsEffect: ModuleID = "io.kevinlee" %% "effectie-cats-effect" % effectieVersion
 lazy val effectieScalazEffect: ModuleID = "io.kevinlee" %% "effectie-scalaz-effect" % effectieVersion
 


### PR DESCRIPTION
# Summary
Close #138 - Support Dotty (Scala 3.0.0-M2)
* Also upgrade Effectie from `1.6.0` to `1.7.0`
