### PR TITLE
logger-f v1.6.0

### DIFF
--- a/changelogs/1.6.0.md
+++ b/changelogs/1.6.0.md
@@ -1,0 +1,4 @@
+## [1.6.0](https://github.com/Kevin-Lee/logger-f/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3A%22milestone12%22) - 2020-12-05
+
+## Done
+* Support Dotty (Scala `3.0.0-M2`) (#138)

--- a/changelogs/1.6.0.md
+++ b/changelogs/1.6.0.md
@@ -2,3 +2,4 @@
 
 ## Done
 * Support Dotty (Scala `3.0.0-M2`) (#138)
+* Upgrade Effectie to `1.7.0`

--- a/project/ProjectInfo.scala
+++ b/project/ProjectInfo.scala
@@ -4,7 +4,7 @@ object ProjectInfo {
 
   final case class ProjectName(projectName: String) extends AnyVal
 
-  val ProjectVersion: String = "1.5.0"
+  val ProjectVersion: String = "1.6.0"
 
   def commonWarts(scalaBinaryVersion: String): Seq[wartremover.Wart] = scalaBinaryVersion match {
     case "2.10" =>


### PR DESCRIPTION
# logger-f v1.6.0
## [1.6.0](https://github.com/Kevin-Lee/logger-f/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3A%22milestone12%22) - 2020-12-05

## Done
* Support Dotty (Scala `3.0.0-M2`) (#138)
* Upgrade Effectie to `1.7.0`
