### PR TITLE
logger-f v1.9.0

### DIFF
--- a/changelogs/1.9.0.md
+++ b/changelogs/1.9.0.md
@@ -1,0 +1,5 @@
+## [1.9.0](https://github.com/Kevin-Lee/logger-f/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3A%22milestone15%22) - 2021-02-21
+
+## Done
+* Upgrade Scala `2.13.3` to `2.13.4` (#156)
+* Support Scala `3.0.0-RC1` (#154)

--- a/project/ProjectInfo.scala
+++ b/project/ProjectInfo.scala
@@ -4,7 +4,7 @@ object ProjectInfo {
 
   final case class ProjectName(projectName: String) extends AnyVal
 
-  val ProjectVersion: String = "1.8.0"
+  val ProjectVersion: String = "1.9.0"
 
   def commonWarts(scalaBinaryVersion: String): Seq[wartremover.Wart] = scalaBinaryVersion match {
     case "2.10" =>


### PR DESCRIPTION
# logger-f v1.9.0
## [1.9.0](https://github.com/Kevin-Lee/logger-f/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3A%22milestone15%22) - 2021-02-21

## Done
* Upgrade Scala `2.13.3` to `2.13.4` (#156)
* Support Scala `3.0.0-RC1` (#154)
