### PR TITLE
logger-f v1.10.0

### DIFF
--- a/changelogs/1.10.0.md
+++ b/changelogs/1.10.0.md
@@ -1,0 +1,4 @@
+## [1.10.0](https://github.com/Kevin-Lee/logger-f/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone16) - 2021-04-26
+
+## Done
+* Support Scala `3.0.0-RC2` and Scala `3.0.0-RC3` (#160)


### PR DESCRIPTION
# logger-f v1.10.0
## [1.10.0](https://github.com/Kevin-Lee/logger-f/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone16) - 2021-04-26

## Done
* Support Scala `3.0.0-RC2` and Scala `3.0.0-RC3` (#160)
