### PR TITLE
logger-f v1.12.0

### DIFF
--- a/changelogs/1.12.0.md
+++ b/changelogs/1.12.0.md
@@ -1,0 +1,5 @@
+## [1.12.0](https://github.com/Kevin-Lee/logger-f/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone18) - 2021-07-24
+
+## Done
+* Upgrade `effectie` to `1.12.0` (#178)
+  - Use `Fx` instead of `EffectConstructor`


### PR DESCRIPTION
# logger-f v1.12.0
## [1.12.0](https://github.com/Kevin-Lee/logger-f/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone18) - 2021-07-24

## Done
* Upgrade `effectie` to `1.12.0` (#178)
  - Use `Fx` instead of `EffectConstructor`
