### PR TITLE
logger-f v1.13.0

### DIFF
--- a/changelogs/1.13.0.md
+++ b/changelogs/1.13.0.md
@@ -1,0 +1,5 @@
+## [1.13.0](https://github.com/Kevin-Lee/logger-f/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone19) - 2021-07-26
+
+## Done
+* Drop Scala `2.11` support (#184)
+* Support Cats Effect 3 (#185)


### PR DESCRIPTION
# logger-f v1.13.0
## [1.13.0](https://github.com/Kevin-Lee/logger-f/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone19) - 2021-07-26

## Done
* Drop Scala `2.11` support (#184)
* Support Cats Effect 3 (#185)
