### PR TITLE
logger-f v1.15.0

### DIFF
--- a/changelogs/1.15.0.md
+++ b/changelogs/1.15.0.md
@@ -1,0 +1,4 @@
+## [1.15.0](https://github.com/Kevin-Lee/logger-f/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone21) - 2021-08-15 ([🎉🇰🇷#](https://en.wikipedia.org/wiki/National_Liberation_Day_of_Korea))
+
+## Done
+* Upgrade Effectie to `1.15.0` (#207)


### PR DESCRIPTION
# logger-f v1.15.0
## [1.15.0](https://github.com/Kevin-Lee/logger-f/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone21) - 2021-08-15 ([🎉🇰🇷#](https://en.wikipedia.org/wiki/National_Liberation_Day_of_Korea))

## Done
* Upgrade Effectie to `1.15.0` (#207)
