### PR TITLE
logger-f v1.16.0 🎃

### DIFF
--- a/changelogs/1.16.0.md
+++ b/changelogs/1.16.0.md
@@ -1,0 +1,4 @@
+## [1.16.0](https://github.com/Kevin-Lee/logger-f/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone22) - 2021-10-31 🎃
+
+## Done
+* Upgrade Effectie to `1.16.0` (#214)


### PR DESCRIPTION
# logger-f v1.16.0 🎃
## [1.16.0](https://github.com/Kevin-Lee/logger-f/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone22) - 2021-10-31 🎃

## Done
* Upgrade Effectie to `1.16.0` (#214)
