### PR TITLE
Update: GitHub Actions - release does not upload artifacts to GitHub release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,8 +144,7 @@ jobs:
             -v \
             clean \
             +packagedArtifacts \
-            ci-release \
-            devOopsGitHubReleaseUploadArtifacts
+            ci-release
 
 
   publish-snapshot:


### PR DESCRIPTION
# Summary
Update: GitHub Actions - release does not upload artifacts to GitHub release