### PR TITLE
logger-f v1.17.0

### DIFF
--- a/changelogs/1.17.0.md
+++ b/changelogs/1.17.0.md
@@ -1,0 +1,4 @@
+## [1.17.0](https://github.com/Kevin-Lee/logger-f/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone23) - 2021-12-14
+
+## Done
+* Bump log4j to fix RCE 0-day exploit found in `log4j` CVE-2021-44228 (#220)


### PR DESCRIPTION
# logger-f v1.17.0
## [1.17.0](https://github.com/Kevin-Lee/logger-f/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone23) - 2021-12-14

## Done
* Bump log4j to fix RCE 0-day exploit found in `log4j` CVE-2021-44228 (#220)
