### PR TITLE
Close #225 - Bump log4j to fix CVE-2021-45046

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -434,7 +434,7 @@ lazy val props =
 
     final val log4sVersion = "1.10.0"
 
-    final val log4JVersion = "2.15.0"
+    final val log4JVersion = "2.16.0"
   }
 
 lazy val libs =


### PR DESCRIPTION
# Summary
Close #225 - Bump log4j to fix CVE-2021-45046