### PR TITLE
logger-f v1.18.0

### DIFF
--- a/changelogs/1.18.0.md
+++ b/changelogs/1.18.0.md
@@ -2,3 +2,4 @@
 
 ## Done
 * Bump `log4j` to fix CVE-2021-45046 (#225)
+* Publish to `s01.oss.sonatype.org` (the new Maven central) (#229)


### PR DESCRIPTION
# logger-f v1.18.0
## [1.18.0](https://github.com/Kevin-Lee/logger-f/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone24) - 2021-12-16

## Done
* Bump `log4j` to fix CVE-2021-45046 (#225)
* Publish to `s01.oss.sonatype.org` (the new Maven central) (#229)
