### PR TITLE
logger-f v1.19.0

### DIFF
--- a/changelogs/1.19.0.md
+++ b/changelogs/1.19.0.md
@@ -1,0 +1,4 @@
+## [1.19.0](https://github.com/Kevin-Lee/logger-f/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone25) - 2021-12-19
+
+## Done
+* Upgrade `logback` to `1.2.9` to solve CVE-2021-42550 (#239)


### PR DESCRIPTION
# logger-f v1.19.0
## [1.19.0](https://github.com/Kevin-Lee/logger-f/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone25) - 2021-12-19

## Done
* Upgrade `logback` to `1.2.9` to solve CVE-2021-42550 (#239)
