### PR TITLE
Close #242 - Upgrade Log4J to 2.17.0 to solve CVE-2021-45105

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -438,7 +438,7 @@ lazy val props =
 
     final val log4sVersion = "1.10.0"
 
-    final val log4JVersion = "2.16.0"
+    final val log4JVersion = "2.17.0"
   }
 
 lazy val libs =


### PR DESCRIPTION
# Summary
Close #242 - Upgrade Log4J to 2.17.0 to solve CVE-2021-45105