### PR TITLE
logger-f v1.20.0

### DIFF
--- a/changelogs/1.20.0.md
+++ b/changelogs/1.20.0.md
@@ -1,0 +1,4 @@
+## [1.20.0](https://github.com/Kevin-Lee/logger-f/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone26) - 2021-12-19
+
+## Done
+* Upgrade Log4J to `2.17.0` to solve CVE-2021-45105 (#242)


### PR DESCRIPTION
# logger-f v1.20.0
## [1.20.0](https://github.com/Kevin-Lee/logger-f/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone26) - 2021-12-19

## Done
* Upgrade Log4J to `2.17.0` to solve CVE-2021-45105 (#242)
