### PR TITLE
Close #280 - Add ToLog[A] type-class to support logging type A

### DIFF
--- a/modules/logger-f-core/src/main/scala-2/loggerf/core/ToLog.scala
+++ b/modules/logger-f-core/src/main/scala-2/loggerf/core/ToLog.scala
@@ -1,0 +1,12 @@
+package loggerf.core
+
+/** @author Kevin Lee
+  * @since 2022-02-18
+  */
+trait ToLog[A] {
+  def toLogMessage(a: A): String
+}
+
+object ToLog {
+  def apply[A: ToLog]: ToLog[A] = implicitly[ToLog[A]]
+}

--- a/modules/logger-f-core/src/main/scala-2/loggerf/syntax/LeveledMessageSyntax.scala
+++ b/modules/logger-f-core/src/main/scala-2/loggerf/syntax/LeveledMessageSyntax.scala
@@ -1,5 +1,7 @@
 package loggerf.syntax
 
+import loggerf.core.ToLog
+
 trait LeveledMessageSyntax {
 
   import loggerf.LogMessage._
@@ -16,6 +18,18 @@ trait LeveledMessageSyntax {
 
   def error(message: String): LogMessage with NotIgnorable =
     LeveledMessage(message, Level.error)
+
+  def debugA[A: ToLog](a: A): LogMessage with NotIgnorable =
+    LeveledMessage(ToLog[A].toLogMessage(a), Level.debug)
+
+  def infoA[A: ToLog](a: A): LogMessage with NotIgnorable =
+    LeveledMessage(ToLog[A].toLogMessage(a), Level.info)
+
+  def warnA[A: ToLog](a: A): LogMessage with NotIgnorable =
+    LeveledMessage(ToLog[A].toLogMessage(a), Level.warn)
+
+  def errorA[A: ToLog](a: A): LogMessage with NotIgnorable =
+    LeveledMessage(ToLog[A].toLogMessage(a), Level.error)
 
   def ignore: LogMessage with Ignorable = Ignore
 

--- a/modules/logger-f-core/src/main/scala-3/loggerf/core/ToLog.scala
+++ b/modules/logger-f-core/src/main/scala-3/loggerf/core/ToLog.scala
@@ -1,0 +1,12 @@
+package loggerf.core
+
+/** @author Kevin Lee
+  * @since 2022-02-18
+  */
+trait ToLog[A] {
+  def toLogMessage(a: A): String
+}
+
+object ToLog {
+  def apply[A: ToLog]: ToLog[A] = summon[ToLog[A]]
+}

--- a/modules/logger-f-core/src/main/scala-3/loggerf/syntax/LeveledMessageSyntax.scala
+++ b/modules/logger-f-core/src/main/scala-3/loggerf/syntax/LeveledMessageSyntax.scala
@@ -1,5 +1,6 @@
 package loggerf.syntax
 
+import loggerf.core.ToLog
 import loggerf.LeveledMessage
 import loggerf.Ignore
 import loggerf.Level
@@ -17,6 +18,18 @@ trait LeveledMessageSyntax {
 
   def error(message: String): LeveledMessage =
     LeveledMessage(message, Level.error)
+
+  def debugA[A: ToLog](a: A): LeveledMessage =
+    LeveledMessage(ToLog[A].toLogMessage(a), Level.debug)
+
+  def infoA[A: ToLog](a: A): LeveledMessage =
+    LeveledMessage(ToLog[A].toLogMessage(a), Level.info)
+
+  def warnA[A: ToLog](a: A): LeveledMessage =
+    LeveledMessage(ToLog[A].toLogMessage(a), Level.warn)
+
+  def errorA[A: ToLog](a: A): LeveledMessage =
+    LeveledMessage(ToLog[A].toLogMessage(a), Level.error)
 
   def ignore: Ignore.type = Ignore
 

--- a/modules/logger-f-core/src/test/scala/loggerf/core/LogForTesting.scala
+++ b/modules/logger-f-core/src/test/scala/loggerf/core/LogForTesting.scala
@@ -1,0 +1,30 @@
+package loggerf.core
+import effectie.core.FxCtor
+import loggerf.core.LogForTesting.Identity
+import loggerf.logger.{CanLog, LoggerForTesting}
+
+/** @author Kevin Lee
+  * @since 2022-02-19
+  */
+final case class LogForTesting(canLog0: LoggerForTesting) extends Log[Identity] {
+  override implicit val EF: FxCtor[Identity] = LogForTesting.FxCtorForTesting
+
+  override def flatMap0[A, B](fa: Identity[A])(f: A => Identity[B]): Identity[B] = f(fa)
+
+  override def canLog: CanLog = canLog0
+}
+object LogForTesting {
+  type Identity[A] = A
+
+  implicit object FxCtorForTesting extends FxCtor[Identity] {
+    override def effectOf[A](a: => A): Identity[A] = a
+
+    override def pureOf[A](a: A): Identity[A] = a
+
+    override def unitOf: Identity[Unit] = ()
+
+    @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+    override def errorOf[A](throwable: Throwable): Identity[A] = throw throwable
+  }
+
+}

--- a/modules/logger-f-core/src/test/scala/loggerf/syntax/LeveledMessageSyntaxSpec.scala
+++ b/modules/logger-f-core/src/test/scala/loggerf/syntax/LeveledMessageSyntaxSpec.scala
@@ -1,0 +1,88 @@
+package loggerf.syntax
+
+import cats._
+import cats.syntax.all._
+import effectie.core._
+import effectie.syntax.all._
+import hedgehog._
+import hedgehog.runner._
+import loggerf.core._
+import loggerf.future.syntax._
+import loggerf.logger.LoggerForTesting
+
+/** @author Kevin Lee
+  * @since 2022-02-19
+  */
+object LeveledMessageSyntaxSpec extends Properties {
+  override def tests: List[Prop] = List(
+    property("test LeveledLogMessage", testLeveledLogMessage),
+    property("test LeveledLogMessage with ToLog", testLeveledLogMessageWithToLog)
+  )
+
+  def testLeveledLogMessage: Property = for {
+    debugMsg <- Gen.string(Gen.unicode, Range.linear(1, 20)).log("debugMsg")
+    infoMsg  <- Gen.string(Gen.unicode, Range.linear(1, 20)).log("infoMsg")
+    warnMsg  <- Gen.string(Gen.unicode, Range.linear(1, 20)).log("warnMsg")
+    errorMsg <- Gen.string(Gen.unicode, Range.linear(1, 20)).log("errorMsg")
+  } yield {
+    val logger: LoggerForTesting = LoggerForTesting()
+
+    def runLog[F[*]: Log: FxCtor: Monad]: F[Unit] =
+      for {
+        _ <- log(pureOf(debugMsg))(debug)
+        _ <- log(pureOf(infoMsg))(info)
+        _ <- log(pureOf(warnMsg))(warn)
+        _ <- log(pureOf(errorMsg))(error)
+      } yield ()
+
+    import LogForTesting.{FxCtorForTesting, Identity}
+    implicit val lgForTesting: Log[Identity] = LogForTesting(logger)
+
+    val expected = LoggerForTesting(
+      debugMessages = Vector(debugMsg),
+      infoMessages = Vector(infoMsg),
+      warnMessages = Vector(warnMsg),
+      errorMessages = Vector(errorMsg)
+    )
+
+    runLog[Identity]
+    logger ==== expected
+  }
+
+  final case class Something(message: String)
+  object Something {
+    implicit val somethingToLog: ToLog[Something] = something => s"Something(message=${something.message})"
+  }
+
+  def testLeveledLogMessageWithToLog: Property = for {
+    debugMsg <- Gen.string(Gen.unicode, Range.linear(1, 20)).map(Something(_)).log("debugMsg")
+    infoMsg  <- Gen.string(Gen.unicode, Range.linear(1, 20)).map(Something(_)).log("infoMsg")
+    warnMsg  <- Gen.string(Gen.unicode, Range.linear(1, 20)).map(Something(_)).log("warnMsg")
+    errorMsg <- Gen.string(Gen.unicode, Range.linear(1, 20)).map(Something(_)).log("errorMsg")
+  } yield {
+
+    val logger: LoggerForTesting = LoggerForTesting()
+
+    def runLog[F[*]: Log: FxCtor: Monad]: F[Unit] =
+      for {
+        _ <- log(pureOf(debugMsg))(debugA)
+        _ <- log(pureOf(infoMsg))(infoA)
+        _ <- log(pureOf(warnMsg))(warnA)
+        _ <- log(pureOf(errorMsg))(errorA)
+      } yield ()
+
+    import LogForTesting.{FxCtorForTesting, Identity}
+    implicit val lgForTesting: Log[Identity] = LogForTesting(logger)
+
+    val expected = LoggerForTesting(
+      debugMessages = Vector(ToLog[Something].toLogMessage(debugMsg)),
+      infoMessages = Vector(ToLog[Something].toLogMessage(infoMsg)),
+      warnMessages = Vector(ToLog[Something].toLogMessage(warnMsg)),
+      errorMessages = Vector(ToLog[Something].toLogMessage(errorMsg))
+    )
+
+    runLog[Identity]
+    logger ==== expected
+  }
+
+}


### PR DESCRIPTION
# Summary
Close #280 - Add `ToLog[A]` type-class to support logging type `A`