### PR TITLE
logger-f v2.0.0-beta1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,8 +20,8 @@ jobs:
       matrix:
         scala:
           - { name: "Scala 2", version: "2.12.13", binary-version: "2.12", java-version: "adopt@1.11", report: "" }
-          - { name: "Scala 2", version: "2.13.5",  binary-version: "2.13", java-version: "adopt@1.11", report: "report" }
-          - { name: "Scala 3", version: "3.0.0",   binary-version: "3",    java-version: "adopt@1.11", report: "" }
+          - { name: "Scala 2", version: "2.13.6",  binary-version: "2.13", java-version: "adopt@1.11", report: "report" }
+          - { name: "Scala 3", version: "3.0.2",   binary-version: "3",    java-version: "adopt@1.11", report: "" }
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/doc-site-build-only.yml
+++ b/.github/workflows/doc-site-build-only.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         scala:
-          - { version: "2.13.5", binary-version: "2.13", java-version: "adopt@1.11" }
+          - { version: "2.13.6", binary-version: "2.13", java-version: "adopt@1.11" }
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/doc-site-publish.yml
+++ b/.github/workflows/doc-site-publish.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         scala:
-          - { version: "2.13.5", binary-version: "2.13", java-version: "adopt@1.11" }
+          - { version: "2.13.6", binary-version: "2.13", java-version: "adopt@1.11" }
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,8 @@ jobs:
       matrix:
         scala:
           - { name: "Scala 2", version: "2.12.13", binary-version: "2.12", java-version: "adopt@1.11", report: "" }
-          - { name: "Scala 2", version: "2.13.5",  binary-version: "2.13", java-version: "adopt@1.11", report: "" }
-          - { name: "Scala 3", version: "3.0.0",   binary-version: "3",    java-version: "adopt@1.11", report: "" }
+          - { name: "Scala 2", version: "2.13.6",  binary-version: "2.13", java-version: "adopt@1.11", report: "" }
+          - { name: "Scala 3", version: "3.0.2",   binary-version: "3",    java-version: "adopt@1.11", report: "" }
 
     steps:
       - uses: actions/checkout@v3
@@ -70,7 +70,7 @@ jobs:
     strategy:
       matrix:
         scala:
-          - { name: "Scala 2", version: "2.13.5", binary-version: "2.13", java-version: "adopt@1.11", report: "report" }
+          - { name: "Scala 2", version: "2.13.6", binary-version: "2.13", java-version: "adopt@1.11", report: "report" }
 
     steps:
       - uses: actions/checkout@v3

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,6 @@ ThisBuild / scalaVersion       := props.ProjectScalaVersion
 ThisBuild / organization       := "io.kevinlee"
 ThisBuild / organizationName   := "Kevin's Code"
 ThisBuild / crossScalaVersions := props.CrossScalaVersions
-ThisBuild / version            := "2.0.0-SNAPSHOT"
 
 ThisBuild / developers := List(
   Developer(
@@ -39,7 +38,7 @@ lazy val loggerF = (project in file("."))
       libraryDependencies.value,
     )
     /* GitHub Release { */,
-    devOopsPackagedArtifacts := List(s"*/target/scala-*/${name.value}*.jar"),
+    devOopsPackagedArtifacts := List(s"*/*/*/target/scala-*/${devOopsArtifactNamePrefix.value}*.jar"),
     /* } GitHub Release */
   )
   .settings(mavenCentralPublishSettings)
@@ -387,8 +386,8 @@ lazy val props =
     final val GitHubUsername = "Kevin-Lee"
     final val RepoName       = "logger-f"
 
-    final val Scala3Versions = List("3.0.0")
-    final val Scala2Versions = List("2.13.5", "2.12.13")
+    final val Scala3Versions = List("3.0.2")
+    final val Scala2Versions = List("2.13.6", "2.12.13")
 
 //    final val ProjectScalaVersion = Scala3Versions.head
     final val ProjectScalaVersion = Scala2Versions.head

--- a/changelogs/2.0.0-beta1.md
+++ b/changelogs/2.0.0-beta1.md
@@ -1,0 +1,13 @@
+## [2.0.0-beta1](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+created%3A%3C%3D2022-03-07) - 2022-05-03
+
+## Done
+* Upgrade `Effectie` to `v2` (#263)
+* Drop `Scalaz Effect` support (#265)
+* Move `Log` typeclass to `core` and keep the instances in the sub-projects (#266)
+* Add `F[A].log()` syntax and more to `logger-f-cats` (#272)
+* Stop releasing `logger-f-cats-effect`, `logger-f-cats-effect3` and `logger-f-monix` (#275)
+* Redesign `LeveledMessage` (#278)
+* Add `ToLog[A]` type-class to support logging type `A` (#280)
+* `ToLog` type-class instance using `cats.Show` (#283)
+* Redesign `loggerf.core.syntax` and `loggerf.cats.syntax` (#285)
+* Support `Scala.js` (#291)

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+ThisBuild / version := "2.0.0-beta1"


### PR DESCRIPTION
# logger-f v2.0.0-beta1
## [2.0.0-beta1](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+created%3A%3C%3D2022-03-07) - 2022-05-03

## Done
* Upgrade `Effectie` to `v2` (#263)
* Drop `Scalaz Effect` support (#265)
* Move `Log` typeclass to `core` and keep the instances in the sub-projects (#266)
* Add `F[A].log()` syntax and more to `logger-f-cats` (#272)
* Stop releasing `logger-f-cats-effect`, `logger-f-cats-effect3` and `logger-f-monix` (#275)
* Redesign `LeveledMessage` (#278)
* Add `ToLog[A]` type-class to support logging type `A` (#280)
* `ToLog` type-class instance using `cats.Show` (#283)
* Redesign `loggerf.core.syntax` and `loggerf.cats.syntax` (#285)
* Support `Scala.js` (#291)