### PR TITLE
Close #318 - Remove `effectie-syntax` from the `logger-f-core` project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -70,7 +70,6 @@ lazy val core    =
       description         := "Logger for F[_] - Core",
       libraryDependencies ++= List(
         libs.effectieCore,
-        libs.effectieSyntax,
         libs.cats % Test,
         libs.extrasConcurrent,
         libs.extrasConcurrentTesting,
@@ -210,7 +209,12 @@ lazy val cats    =
   module(ProjectName("cats"), crossProject(JVMPlatform, JSPlatform))
     .settings(
       description         := "Logger for F[_] - Cats",
-      libraryDependencies ++= libs.hedgehogLibs ++ List(libs.effectieCore, libs.cats, libs.extrasCats),
+      libraryDependencies ++= libs.hedgehogLibs ++ List(
+        libs.effectieCore,
+        libs.cats,
+        libs.extrasCats,
+        libs.effectieSyntax,
+      ),
       libraryDependencies := libraryDependenciesRemoveScala3Incompatible(
         scalaVersion.value,
         libraryDependencies.value

--- a/modules/logger-f-core/shared/src/main/scala-2/loggerf/core/Log.scala
+++ b/modules/logger-f-core/shared/src/main/scala-2/loggerf/core/Log.scala
@@ -1,7 +1,6 @@
 package loggerf.core
 
 import effectie.core.FxCtor
-import effectie.syntax.all._
 import loggerf.LogMessage
 import loggerf.LogMessage.{MaybeIgnorable, NotIgnorable}
 import loggerf.logger.CanLog
@@ -20,7 +19,7 @@ trait Log[F[*]] {
     flatMap0(fa) { a =>
       toLeveledMessage(a) match {
         case LogMessage.LeveledMessage(message, level) =>
-          flatMap0(effectOf(canLog.getLogger(level)(message)))(_ => pureOf(a))
+          flatMap0(EF.effectOf(canLog.getLogger(level)(message)))(_ => EF.pureOf(a))
       }
     }
 
@@ -34,18 +33,18 @@ trait Log[F[*]] {
       case None =>
         ifEmpty match {
           case LogMessage.Ignore =>
-            pureOf(None)
+            EF.pureOf(None)
 
           case LogMessage.LeveledMessage(message, level) =>
-            flatMap0(effectOf(canLog.getLogger(level)(message)))(_ => pureOf(None))
+            flatMap0(EF.effectOf(canLog.getLogger(level)(message)))(_ => EF.pureOf(None))
         }
       case Some(a) =>
         toLeveledMessage(a) match {
           case LogMessage.LeveledMessage(message, level) =>
-            flatMap0(effectOf(canLog.getLogger(level)(message)))(_ => pureOf(Some(a)))
+            flatMap0(EF.effectOf(canLog.getLogger(level)(message)))(_ => EF.pureOf(Some(a)))
 
           case LogMessage.Ignore =>
-            pureOf(Some(a))
+            EF.pureOf(Some(a))
         }
     }
 
@@ -59,18 +58,18 @@ trait Log[F[*]] {
       case Left(l) =>
         leftToMessage(l) match {
           case LogMessage.LeveledMessage(message, level) =>
-            flatMap0(effectOf(canLog.getLogger(level)(message)))(_ => pureOf(Left(l)))
+            flatMap0(EF.effectOf(canLog.getLogger(level)(message)))(_ => EF.pureOf(Left(l)))
 
           case LogMessage.Ignore =>
-            pureOf(Left(l))
+            EF.pureOf(Left(l))
         }
       case Right(r) =>
         rightToMessage(r) match {
           case LogMessage.LeveledMessage(message, level) =>
-            flatMap0(effectOf(canLog.getLogger(level)(message)))(_ => pureOf(Right(r)))
+            flatMap0(EF.effectOf(canLog.getLogger(level)(message)))(_ => EF.pureOf(Right(r)))
 
           case LogMessage.Ignore =>
-            pureOf(Right(r))
+            EF.pureOf(Right(r))
         }
     }
 

--- a/modules/logger-f-core/shared/src/main/scala-3/loggerf/core/Log.scala
+++ b/modules/logger-f-core/shared/src/main/scala-3/loggerf/core/Log.scala
@@ -1,7 +1,6 @@
 package loggerf.core
 
 import effectie.core.FxCtor
-import effectie.syntax.all.{effectOf, pureOf}
 import loggerf.LeveledMessage
 import loggerf.Ignore
 import loggerf.logger.CanLog
@@ -20,7 +19,7 @@ trait Log[F[*]] {
     flatMap0(fa) { a =>
       toLeveledMessage(a) match {
         case LeveledMessage(message, level) =>
-          flatMap0(effectOf(canLog.getLogger(level)(message)))(_ => pureOf(a))
+          flatMap0(EF.effectOf(canLog.getLogger(level)(message)))(_ => EF.pureOf(a))
       }
     }
 
@@ -34,18 +33,18 @@ trait Log[F[*]] {
       case None =>
         ifEmpty match {
           case Ignore =>
-            pureOf(None)
+            EF.pureOf(None)
 
           case LeveledMessage(message, level) =>
-            flatMap0(effectOf(canLog.getLogger(level)(message)))(_ => pureOf(None))
+            flatMap0(EF.effectOf(canLog.getLogger(level)(message)))(_ => EF.pureOf(None))
         }
       case Some(a) =>
         toLeveledMessage(a) match {
           case LeveledMessage(message, level) =>
-            flatMap0(effectOf(canLog.getLogger(level)(message)))(_ => pureOf(Some(a)))
+            flatMap0(EF.effectOf(canLog.getLogger(level)(message)))(_ => EF.pureOf(Some(a)))
 
           case Ignore =>
-            pureOf(Some(a))
+            EF.pureOf(Some(a))
         }
     }
 
@@ -60,18 +59,18 @@ trait Log[F[*]] {
       case Left(l) =>
         leftToMessage(l) match {
           case LeveledMessage(message, level) =>
-            flatMap0(effectOf(canLog.getLogger(level)(message)))(_ => pureOf(Left(l)))
+            flatMap0(EF.effectOf(canLog.getLogger(level)(message)))(_ => EF.pureOf(Left(l)))
 
           case Ignore =>
-            pureOf(Left(l))
+            EF.pureOf(Left(l))
         }
       case Right(r) =>
         rightToMessage(r) match {
           case LeveledMessage(message, level) =>
-            flatMap0(effectOf(canLog.getLogger(level)(message)))(_ => pureOf(Right(r)))
+            flatMap0(EF.effectOf(canLog.getLogger(level)(message)))(_ => EF.pureOf(Right(r)))
 
           case Ignore =>
-            pureOf(Right(r))
+            EF.pureOf(Right(r))
         }
     }
 

--- a/modules/logger-f-core/shared/src/test/scala/loggerf/future/instancesSpec.scala
+++ b/modules/logger-f-core/shared/src/test/scala/loggerf/future/instancesSpec.scala
@@ -6,7 +6,6 @@ import cats.syntax.flatMap._
 import cats.syntax.functor._
 import cats.syntax.option._
 import effectie.core._
-import effectie.syntax.all._
 import extras.concurrent.testing.ConcurrentSupport
 import extras.concurrent.testing.types.{ErrorLogger, WaitFor}
 import hedgehog._
@@ -49,10 +48,10 @@ object instancesSpec extends Properties {
 
     def runLog[F[*]: Fx: Log: Monad]: F[Unit] =
       (for {
-        _ <- Log[F].log(effectOf(debugMsg))(debug)
-        _ <- Log[F].log(effectOf(infoMsg))(info)
-        _ <- Log[F].log(effectOf(warnMsg))(warn)
-        _ <- Log[F].log(effectOf(errorMsg))(error)
+        _ <- Log[F].log(Fx[F].effectOf(debugMsg))(debug)
+        _ <- Log[F].log(Fx[F].effectOf(infoMsg))(info)
+        _ <- Log[F].log(Fx[F].effectOf(warnMsg))(warn)
+        _ <- Log[F].log(Fx[F].effectOf(errorMsg))(error)
       } yield ())
 
     val expected = LoggerForTesting(
@@ -84,10 +83,10 @@ object instancesSpec extends Properties {
 
     def runLog[F[*]: Fx: Log: Monad](oa: Option[String]): F[Option[Unit]] =
       (for {
-        _ <- Log[F].log(effectOf(oa))(error(ifEmptyMsg), debug)
-        _ <- Log[F].log(effectOf(oa))(error(ifEmptyMsg), info)
-        _ <- Log[F].log(effectOf(oa))(error(ifEmptyMsg), warn)
-        _ <- Log[F].log(effectOf(oa))(error(ifEmptyMsg), error)
+        _ <- Log[F].log(Fx[F].effectOf(oa))(error(ifEmptyMsg), debug)
+        _ <- Log[F].log(Fx[F].effectOf(oa))(error(ifEmptyMsg), info)
+        _ <- Log[F].log(Fx[F].effectOf(oa))(error(ifEmptyMsg), warn)
+        _ <- Log[F].log(Fx[F].effectOf(oa))(error(ifEmptyMsg), error)
       } yield ().some)
 
     val expected = logMsg match {
@@ -127,10 +126,10 @@ object instancesSpec extends Properties {
 
     def runLog[F[*]: Fx: Log: Monad](oa: Option[String]): F[Option[Unit]] =
       (for {
-        _ <- Log[F].log(effectOf(oa))(ignore, debug)
-        _ <- Log[F].log(effectOf(oa))(ignore, info)
-        _ <- Log[F].log(effectOf(oa))(ignore, warn)
-        _ <- Log[F].log(effectOf(oa))(ignore, error)
+        _ <- Log[F].log(Fx[F].effectOf(oa))(ignore, debug)
+        _ <- Log[F].log(Fx[F].effectOf(oa))(ignore, info)
+        _ <- Log[F].log(Fx[F].effectOf(oa))(ignore, warn)
+        _ <- Log[F].log(Fx[F].effectOf(oa))(ignore, error)
       } yield ().some)
 
     val expected = logMsg match {
@@ -171,10 +170,10 @@ object instancesSpec extends Properties {
 
     def runLog[F[*]: Fx: Log: Monad](oa: Option[String]): F[Option[Unit]] =
       (for {
-        _ <- Log[F].log(effectOf(oa))(error(ifEmptyMsg), _ => ignore)
-        _ <- Log[F].log(effectOf(oa))(error(ifEmptyMsg), _ => ignore)
-        _ <- Log[F].log(effectOf(oa))(error(ifEmptyMsg), _ => ignore)
-        _ <- Log[F].log(effectOf(oa))(error(ifEmptyMsg), _ => ignore)
+        _ <- Log[F].log(Fx[F].effectOf(oa))(error(ifEmptyMsg), _ => ignore)
+        _ <- Log[F].log(Fx[F].effectOf(oa))(error(ifEmptyMsg), _ => ignore)
+        _ <- Log[F].log(Fx[F].effectOf(oa))(error(ifEmptyMsg), _ => ignore)
+        _ <- Log[F].log(Fx[F].effectOf(oa))(error(ifEmptyMsg), _ => ignore)
       } yield ().some)
 
     val expected = logMsg match {
@@ -215,10 +214,10 @@ object instancesSpec extends Properties {
     implicit val logger: LoggerForTesting = LoggerForTesting()
 
     def runLog[F[*]: Fx: Log: Monad](eab: Either[String, Int]): F[Either[String, Unit]] = for {
-      _ <- Log[F].log(effectOf(eab))(error, b => debug(b.toString))
-      _ <- Log[F].log(effectOf(eab))(error, b => info(b.toString))
-      _ <- Log[F].log(effectOf(eab))(error, b => warn(b.toString))
-      _ <- Log[F].log(effectOf(eab))(error, b => error(b.toString))
+      _ <- Log[F].log(Fx[F].effectOf(eab))(error, b => debug(b.toString))
+      _ <- Log[F].log(Fx[F].effectOf(eab))(error, b => info(b.toString))
+      _ <- Log[F].log(Fx[F].effectOf(eab))(error, b => warn(b.toString))
+      _ <- Log[F].log(Fx[F].effectOf(eab))(error, b => error(b.toString))
     } yield ().asRight[String]
 
     val eab = if (isRight) rightInt.asRight[String] else leftString.asLeft[Int]
@@ -261,10 +260,10 @@ object instancesSpec extends Properties {
     implicit val logger: LoggerForTesting = LoggerForTesting()
 
     def runLog[F[*]: Fx: Log: Monad](eab: Either[String, Int]): F[Either[String, Unit]] = for {
-      _ <- Log[F].log(effectOf(eab))(_ => ignore, b => debug(b.toString))
-      _ <- Log[F].log(effectOf(eab))(_ => ignore, b => info(b.toString))
-      _ <- Log[F].log(effectOf(eab))(_ => ignore, b => warn(b.toString))
-      _ <- Log[F].log(effectOf(eab))(_ => ignore, b => error(b.toString))
+      _ <- Log[F].log(Fx[F].effectOf(eab))(_ => ignore, b => debug(b.toString))
+      _ <- Log[F].log(Fx[F].effectOf(eab))(_ => ignore, b => info(b.toString))
+      _ <- Log[F].log(Fx[F].effectOf(eab))(_ => ignore, b => warn(b.toString))
+      _ <- Log[F].log(Fx[F].effectOf(eab))(_ => ignore, b => error(b.toString))
     } yield ().asRight[String]
 
     val eab = if (isRight) rightInt.asRight[String] else leftString.asLeft[Int]
@@ -307,10 +306,10 @@ object instancesSpec extends Properties {
     implicit val logger: LoggerForTesting = LoggerForTesting()
 
     def runLog[F[*]: Fx: Log: Monad](eab: Either[String, Int]): F[Either[String, Unit]] = for {
-      _ <- Log[F].log(effectOf(eab))(error, _ => ignore)
-      _ <- Log[F].log(effectOf(eab))(error, _ => ignore)
-      _ <- Log[F].log(effectOf(eab))(error, _ => ignore)
-      _ <- Log[F].log(effectOf(eab))(error, _ => ignore)
+      _ <- Log[F].log(Fx[F].effectOf(eab))(error, _ => ignore)
+      _ <- Log[F].log(Fx[F].effectOf(eab))(error, _ => ignore)
+      _ <- Log[F].log(Fx[F].effectOf(eab))(error, _ => ignore)
+      _ <- Log[F].log(Fx[F].effectOf(eab))(error, _ => ignore)
     } yield ().asRight[String]
 
     val eab = if (isRight) rightInt.asRight[String] else leftString.asLeft[Int]

--- a/modules/logger-f-core/shared/src/test/scala/loggerf/future/syntaxSpec.scala
+++ b/modules/logger-f-core/shared/src/test/scala/loggerf/future/syntaxSpec.scala
@@ -6,7 +6,6 @@ import cats.syntax.flatMap._
 import cats.syntax.functor._
 import cats.syntax.option._
 import effectie.core.FxCtor
-import effectie.syntax.all._
 import extras.concurrent.testing.ConcurrentSupport
 import extras.concurrent.testing.types.{ErrorLogger, WaitFor}
 import hedgehog._
@@ -56,10 +55,10 @@ object syntaxSpec extends Properties {
 
     def runLog[F[*]: FxCtor: Log: Monad]: F[Unit] =
       (for {
-        _ <- log(effectOf(debugMsg))(debug)
-        _ <- log(effectOf(infoMsg))(info)
-        _ <- log(effectOf(warnMsg))(warn)
-        _ <- log(effectOf(errorMsg))(error)
+        _ <- log(FxCtor[F].effectOf(debugMsg))(debug)
+        _ <- log(FxCtor[F].effectOf(infoMsg))(info)
+        _ <- log(FxCtor[F].effectOf(warnMsg))(warn)
+        _ <- log(FxCtor[F].effectOf(errorMsg))(error)
       } yield ())
 
     val expected = LoggerForTesting(
@@ -90,10 +89,10 @@ object syntaxSpec extends Properties {
 
     def runLog[F[*]: FxCtor: Log: Monad](oa: Option[String]): F[Option[Unit]] =
       (for {
-        _ <- log(effectOf(oa))(error(ifEmptyMsg), debug)
-        _ <- log(effectOf(oa))(error(ifEmptyMsg), info)
-        _ <- log(effectOf(oa))(error(ifEmptyMsg), warn)
-        _ <- log(effectOf(oa))(error(ifEmptyMsg), error)
+        _ <- log(FxCtor[F].effectOf(oa))(error(ifEmptyMsg), debug)
+        _ <- log(FxCtor[F].effectOf(oa))(error(ifEmptyMsg), info)
+        _ <- log(FxCtor[F].effectOf(oa))(error(ifEmptyMsg), warn)
+        _ <- log(FxCtor[F].effectOf(oa))(error(ifEmptyMsg), error)
       } yield ().some)
 
     val expected = logMsg match {
@@ -134,10 +133,10 @@ object syntaxSpec extends Properties {
 
     def runLog[F[*]: FxCtor: Log: Monad](oa: Option[String]): F[Option[Unit]] =
       for {
-        _ <- log(effectOf(oa))(ignore, debug)
-        _ <- log(effectOf(oa))(ignore, info)
-        _ <- log(effectOf(oa))(ignore, warn)
-        _ <- log(effectOf(oa))(ignore, error)
+        _ <- log(FxCtor[F].effectOf(oa))(ignore, debug)
+        _ <- log(FxCtor[F].effectOf(oa))(ignore, info)
+        _ <- log(FxCtor[F].effectOf(oa))(ignore, warn)
+        _ <- log(FxCtor[F].effectOf(oa))(ignore, error)
       } yield ().some
 
     val expected = logMsg match {
@@ -179,10 +178,10 @@ object syntaxSpec extends Properties {
 
     def runLog[F[*]: FxCtor: Log: Monad](oa: Option[String]): F[Option[Unit]] =
       for {
-        _ <- log(effectOf(oa))(error(ifEmptyMsg), _ => ignore)
-        _ <- log(effectOf(oa))(error(ifEmptyMsg), _ => ignore)
-        _ <- log(effectOf(oa))(error(ifEmptyMsg), _ => ignore)
-        _ <- log(effectOf(oa))(error(ifEmptyMsg), _ => ignore)
+        _ <- log(FxCtor[F].effectOf(oa))(error(ifEmptyMsg), _ => ignore)
+        _ <- log(FxCtor[F].effectOf(oa))(error(ifEmptyMsg), _ => ignore)
+        _ <- log(FxCtor[F].effectOf(oa))(error(ifEmptyMsg), _ => ignore)
+        _ <- log(FxCtor[F].effectOf(oa))(error(ifEmptyMsg), _ => ignore)
       } yield ().some
 
     val expected = logMsg match {
@@ -224,10 +223,10 @@ object syntaxSpec extends Properties {
     implicit val logger: LoggerForTesting = LoggerForTesting()
 
     def runLog[F[*]: FxCtor: Log: Monad](eab: Either[String, Int]): F[Either[String, Unit]] = for {
-      _ <- log(effectOf(eab))(error, b => debug(b.toString))
-      _ <- log(effectOf(eab))(error, b => info(b.toString))
-      _ <- log(effectOf(eab))(error, b => warn(b.toString))
-      _ <- log(effectOf(eab))(error, b => error(b.toString))
+      _ <- log(FxCtor[F].effectOf(eab))(error, b => debug(b.toString))
+      _ <- log(FxCtor[F].effectOf(eab))(error, b => info(b.toString))
+      _ <- log(FxCtor[F].effectOf(eab))(error, b => warn(b.toString))
+      _ <- log(FxCtor[F].effectOf(eab))(error, b => error(b.toString))
     } yield ().asRight[String]
 
     val eab = if (isRight) rightInt.asRight[String] else leftString.asLeft[Int]
@@ -271,10 +270,10 @@ object syntaxSpec extends Properties {
     implicit val logger: LoggerForTesting = LoggerForTesting()
 
     def runLog[F[*]: FxCtor: Log: Monad](eab: Either[String, Int]): F[Either[String, Unit]] = for {
-      _ <- log(effectOf(eab))(_ => ignore, b => debug(b.toString))
-      _ <- log(effectOf(eab))(_ => ignore, b => info(b.toString))
-      _ <- log(effectOf(eab))(_ => ignore, b => warn(b.toString))
-      _ <- log(effectOf(eab))(_ => ignore, b => error(b.toString))
+      _ <- log(FxCtor[F].effectOf(eab))(_ => ignore, b => debug(b.toString))
+      _ <- log(FxCtor[F].effectOf(eab))(_ => ignore, b => info(b.toString))
+      _ <- log(FxCtor[F].effectOf(eab))(_ => ignore, b => warn(b.toString))
+      _ <- log(FxCtor[F].effectOf(eab))(_ => ignore, b => error(b.toString))
     } yield ().asRight[String]
 
     val eab = if (isRight) rightInt.asRight[String] else leftString.asLeft[Int]
@@ -318,10 +317,10 @@ object syntaxSpec extends Properties {
     implicit val logger: LoggerForTesting = LoggerForTesting()
 
     def runLog[F[*]: FxCtor: Log: Monad](eab: Either[String, Int]): F[Either[String, Unit]] = for {
-      _ <- log(effectOf(eab))(error, _ => ignore)
-      _ <- log(effectOf(eab))(error, _ => ignore)
-      _ <- log(effectOf(eab))(error, _ => ignore)
-      _ <- log(effectOf(eab))(error, _ => ignore)
+      _ <- log(FxCtor[F].effectOf(eab))(error, _ => ignore)
+      _ <- log(FxCtor[F].effectOf(eab))(error, _ => ignore)
+      _ <- log(FxCtor[F].effectOf(eab))(error, _ => ignore)
+      _ <- log(FxCtor[F].effectOf(eab))(error, _ => ignore)
     } yield ().asRight[String]
 
     val eab = if (isRight) rightInt.asRight[String] else leftString.asLeft[Int]
@@ -371,10 +370,10 @@ object syntaxSpec extends Properties {
 
       def runLog[F[*]: FxCtor: Log: Monad]: F[Unit] =
         (for {
-          _ <- effectOf(debugMsg).log(debug)
-          _ <- effectOf(infoMsg).log(info)
-          _ <- effectOf(warnMsg).log(warn)
-          _ <- effectOf(errorMsg).log(error)
+          _ <- FxCtor[F].effectOf(debugMsg).log(debug)
+          _ <- FxCtor[F].effectOf(infoMsg).log(info)
+          _ <- FxCtor[F].effectOf(warnMsg).log(warn)
+          _ <- FxCtor[F].effectOf(errorMsg).log(error)
         } yield ())
 
       val expected = LoggerForTesting(
@@ -405,10 +404,10 @@ object syntaxSpec extends Properties {
 
       def runLog[F[*]: FxCtor: Log: Monad](oa: Option[String]): F[Option[Unit]] =
         (for {
-          _ <- effectOf(oa).log(error(ifEmptyMsg), debug)
-          _ <- effectOf(oa).log(error(ifEmptyMsg), info)
-          _ <- effectOf(oa).log(error(ifEmptyMsg), warn)
-          _ <- effectOf(oa).log(error(ifEmptyMsg), error)
+          _ <- FxCtor[F].effectOf(oa).log(error(ifEmptyMsg), debug)
+          _ <- FxCtor[F].effectOf(oa).log(error(ifEmptyMsg), info)
+          _ <- FxCtor[F].effectOf(oa).log(error(ifEmptyMsg), warn)
+          _ <- FxCtor[F].effectOf(oa).log(error(ifEmptyMsg), error)
         } yield ().some)
 
       val expected = logMsg match {
@@ -449,10 +448,10 @@ object syntaxSpec extends Properties {
 
       def runLog[F[*]: FxCtor: Log: Monad](oa: Option[String]): F[Option[Unit]] =
         for {
-          _ <- effectOf(oa).log(ignore, debug)
-          _ <- effectOf(oa).log(ignore, info)
-          _ <- effectOf(oa).log(ignore, warn)
-          _ <- effectOf(oa).log(ignore, error)
+          _ <- FxCtor[F].effectOf(oa).log(ignore, debug)
+          _ <- FxCtor[F].effectOf(oa).log(ignore, info)
+          _ <- FxCtor[F].effectOf(oa).log(ignore, warn)
+          _ <- FxCtor[F].effectOf(oa).log(ignore, error)
         } yield ().some
 
       val expected = logMsg match {
@@ -494,10 +493,10 @@ object syntaxSpec extends Properties {
 
       def runLog[F[*]: FxCtor: Log: Monad](oa: Option[String]): F[Option[Unit]] =
         for {
-          _ <- effectOf(oa).log(error(ifEmptyMsg), _ => ignore)
-          _ <- effectOf(oa).log(error(ifEmptyMsg), _ => ignore)
-          _ <- effectOf(oa).log(error(ifEmptyMsg), _ => ignore)
-          _ <- effectOf(oa).log(error(ifEmptyMsg), _ => ignore)
+          _ <- FxCtor[F].effectOf(oa).log(error(ifEmptyMsg), _ => ignore)
+          _ <- FxCtor[F].effectOf(oa).log(error(ifEmptyMsg), _ => ignore)
+          _ <- FxCtor[F].effectOf(oa).log(error(ifEmptyMsg), _ => ignore)
+          _ <- FxCtor[F].effectOf(oa).log(error(ifEmptyMsg), _ => ignore)
         } yield ().some
 
       val expected = logMsg match {
@@ -539,10 +538,10 @@ object syntaxSpec extends Properties {
       implicit val logger: LoggerForTesting = LoggerForTesting()
 
       def runLog[F[*]: FxCtor: Log: Monad](eab: Either[String, Int]): F[Either[String, Unit]] = for {
-        _ <- effectOf(eab).log(error, b => debug(b.toString))
-        _ <- effectOf(eab).log(error, b => info(b.toString))
-        _ <- effectOf(eab).log(error, b => warn(b.toString))
-        _ <- effectOf(eab).log(error, b => error(b.toString))
+        _ <- FxCtor[F].effectOf(eab).log(error, b => debug(b.toString))
+        _ <- FxCtor[F].effectOf(eab).log(error, b => info(b.toString))
+        _ <- FxCtor[F].effectOf(eab).log(error, b => warn(b.toString))
+        _ <- FxCtor[F].effectOf(eab).log(error, b => error(b.toString))
       } yield ().asRight[String]
 
       val eab = if (isRight) rightInt.asRight[String] else leftString.asLeft[Int]
@@ -586,10 +585,10 @@ object syntaxSpec extends Properties {
       implicit val logger: LoggerForTesting = LoggerForTesting()
 
       def runLog[F[*]: FxCtor: Log: Monad](eab: Either[String, Int]): F[Either[String, Unit]] = for {
-        _ <- effectOf(eab).log(_ => ignore, b => debug(b.toString))
-        _ <- effectOf(eab).log(_ => ignore, b => info(b.toString))
-        _ <- effectOf(eab).log(_ => ignore, b => warn(b.toString))
-        _ <- effectOf(eab).log(_ => ignore, b => error(b.toString))
+        _ <- FxCtor[F].effectOf(eab).log(_ => ignore, b => debug(b.toString))
+        _ <- FxCtor[F].effectOf(eab).log(_ => ignore, b => info(b.toString))
+        _ <- FxCtor[F].effectOf(eab).log(_ => ignore, b => warn(b.toString))
+        _ <- FxCtor[F].effectOf(eab).log(_ => ignore, b => error(b.toString))
       } yield ().asRight[String]
 
       val eab = if (isRight) rightInt.asRight[String] else leftString.asLeft[Int]
@@ -633,10 +632,10 @@ object syntaxSpec extends Properties {
       implicit val logger: LoggerForTesting = LoggerForTesting()
 
       def runLog[F[*]: FxCtor: Log: Monad](eab: Either[String, Int]): F[Either[String, Unit]] = for {
-        _ <- effectOf(eab).log(error, _ => ignore)
-        _ <- effectOf(eab).log(error, _ => ignore)
-        _ <- effectOf(eab).log(error, _ => ignore)
-        _ <- effectOf(eab).log(error, _ => ignore)
+        _ <- FxCtor[F].effectOf(eab).log(error, _ => ignore)
+        _ <- FxCtor[F].effectOf(eab).log(error, _ => ignore)
+        _ <- FxCtor[F].effectOf(eab).log(error, _ => ignore)
+        _ <- FxCtor[F].effectOf(eab).log(error, _ => ignore)
       } yield ().asRight[String]
 
       val eab = if (isRight) rightInt.asRight[String] else leftString.asLeft[Int]

--- a/modules/logger-f-core/shared/src/test/scala/loggerf/syntax/LeveledMessageSyntaxSpec.scala
+++ b/modules/logger-f-core/shared/src/test/scala/loggerf/syntax/LeveledMessageSyntaxSpec.scala
@@ -3,7 +3,6 @@ package loggerf.syntax
 import cats._
 import cats.syntax.all._
 import effectie.core._
-import effectie.syntax.all._
 import hedgehog._
 import hedgehog.runner._
 import loggerf.core._
@@ -29,10 +28,10 @@ object LeveledMessageSyntaxSpec extends Properties {
 
     def runLog[F[*]: Log: FxCtor: Monad]: F[Unit] =
       for {
-        _ <- log(pureOf(debugMsg))(debug)
-        _ <- log(pureOf(infoMsg))(info)
-        _ <- log(pureOf(warnMsg))(warn)
-        _ <- log(pureOf(errorMsg))(error)
+        _ <- log(FxCtor[F].pureOf(debugMsg))(debug)
+        _ <- log(FxCtor[F].pureOf(infoMsg))(info)
+        _ <- log(FxCtor[F].pureOf(warnMsg))(warn)
+        _ <- log(FxCtor[F].pureOf(errorMsg))(error)
       } yield ()
 
     import LogForTesting.{FxCtorForTesting, Identity}
@@ -65,10 +64,10 @@ object LeveledMessageSyntaxSpec extends Properties {
 
     def runLog[F[*]: Log: FxCtor: Monad]: F[Unit] =
       for {
-        _ <- log(pureOf(debugMsg))(debugA)
-        _ <- log(pureOf(infoMsg))(infoA)
-        _ <- log(pureOf(warnMsg))(warnA)
-        _ <- log(pureOf(errorMsg))(errorA)
+        _ <- log(FxCtor[F].pureOf(debugMsg))(debugA)
+        _ <- log(FxCtor[F].pureOf(infoMsg))(infoA)
+        _ <- log(FxCtor[F].pureOf(warnMsg))(warnA)
+        _ <- log(FxCtor[F].pureOf(errorMsg))(errorA)
       } yield ()
 
     import LogForTesting.{FxCtorForTesting, Identity}


### PR DESCRIPTION
# Summary
Close #318 - Remove `effectie-syntax` from the `logger-f-core` project