### PR TITLE
Close #321 - Move `loggerf.cats.instances.logF` to `loggerf.instances.cats`

### DIFF
--- a/modules/logger-f-cats-effect/shared/src/test/scala/loggerf/cats/instancesSpec.scala
+++ b/modules/logger-f-cats-effect/shared/src/test/scala/loggerf/cats/instancesSpec.scala
@@ -46,7 +46,7 @@ object instancesSpec extends Properties {
       } yield ())
 
     import effectie.ce2.fx.ioFx
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     runLog[IO].unsafeRunSync()
 
     val expected = LoggerForTesting(
@@ -75,7 +75,7 @@ object instancesSpec extends Properties {
       } yield ().some)
 
     import effectie.ce2.fx.ioFx
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     runLog[IO](logMsg).unsafeRunSync()
 
     val expected = logMsg match {
@@ -114,7 +114,7 @@ object instancesSpec extends Properties {
       } yield ().some)
 
     import effectie.ce2.fx.ioFx
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     runLog[IO](logMsg).unsafeRunSync()
 
     val expected = logMsg match {
@@ -154,7 +154,7 @@ object instancesSpec extends Properties {
       } yield ().some)
 
     import effectie.ce2.fx.ioFx
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     runLog[IO](logMsg).unsafeRunSync()
 
     val expected = logMsg match {
@@ -194,7 +194,7 @@ object instancesSpec extends Properties {
       } yield ().some)
 
     import effectie.ce2.fx.ioFx
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     runLog[IO](logMsg).unsafeRunSync()
 
     val expected = logMsg match {
@@ -236,7 +236,7 @@ object instancesSpec extends Properties {
     val eab = if (isRight) rightInt.asRight[String] else leftString.asLeft[Int]
 
     import effectie.ce2.fx.ioFx
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     runLog[IO](eab).unsafeRunSync()
 
     val expected = eab match {
@@ -278,7 +278,7 @@ object instancesSpec extends Properties {
     val eab = if (isRight) rightInt.asRight[String] else leftString.asLeft[Int]
 
     import effectie.ce2.fx.ioFx
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     runLog[IO](eab).unsafeRunSync()
 
     val expected = eab match {
@@ -320,7 +320,7 @@ object instancesSpec extends Properties {
     val eab = if (isRight) rightInt.asRight[String] else leftString.asLeft[Int]
 
     import effectie.ce2.fx.ioFx
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     runLog[IO](eab).unsafeRunSync()
 
     val expected = eab match {
@@ -362,7 +362,7 @@ object instancesSpec extends Properties {
     val eab = if (isRight) rightInt.asRight[String] else leftString.asLeft[Int]
 
     import effectie.ce2.fx.ioFx
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     runLog[IO](eab).unsafeRunSync()
 
     val expected = eab match {
@@ -404,7 +404,7 @@ object instancesSpec extends Properties {
     val eab = if (isRight) rightInt.asRight[String] else leftString.asLeft[Int]
 
     import effectie.ce2.fx.ioFx
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     runLog[IO](eab).unsafeRunSync()
 
     val expected = eab match {

--- a/modules/logger-f-cats-effect/shared/src/test/scala/loggerf/cats/syntaxSpec.scala
+++ b/modules/logger-f-cats-effect/shared/src/test/scala/loggerf/cats/syntaxSpec.scala
@@ -77,7 +77,7 @@ object syntaxSpec extends Properties {
       } yield ())
 
     import effectie.ce2.fx.ioFx
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     runLog[IO].unsafeRunSync()
 
     val expected = LoggerForTesting(
@@ -106,7 +106,7 @@ object syntaxSpec extends Properties {
       } yield ().some)
 
     import effectie.ce2.fx.ioFx
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     runLog[IO](logMsg).unsafeRunSync()
 
     val expected = logMsg match {
@@ -145,7 +145,7 @@ object syntaxSpec extends Properties {
       } yield ().some)
 
     import effectie.ce2.fx.ioFx
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     runLog[IO](logMsg).unsafeRunSync()
 
     val expected = logMsg match {
@@ -185,7 +185,7 @@ object syntaxSpec extends Properties {
       } yield ().some)
 
     import effectie.ce2.fx.ioFx
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     runLog[IO](logMsg).unsafeRunSync()
 
     val expected = logMsg match {
@@ -225,7 +225,7 @@ object syntaxSpec extends Properties {
       } yield ().some)
 
     import effectie.ce2.fx.ioFx
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     runLog[IO](logMsg).unsafeRunSync()
 
     val expected = logMsg match {
@@ -267,7 +267,7 @@ object syntaxSpec extends Properties {
     val eab = if (isRight) rightInt.asRight[String] else leftString.asLeft[Int]
 
     import effectie.ce2.fx.ioFx
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     runLog[IO](eab).unsafeRunSync()
 
     val expected = eab match {
@@ -309,7 +309,7 @@ object syntaxSpec extends Properties {
     val eab = if (isRight) rightInt.asRight[String] else leftString.asLeft[Int]
 
     import effectie.ce2.fx.ioFx
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     runLog[IO](eab).unsafeRunSync()
 
     val expected = eab match {
@@ -351,7 +351,7 @@ object syntaxSpec extends Properties {
     val eab = if (isRight) rightInt.asRight[String] else leftString.asLeft[Int]
 
     import effectie.ce2.fx.ioFx
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     runLog[IO](eab).unsafeRunSync()
 
     val expected = eab match {
@@ -393,7 +393,7 @@ object syntaxSpec extends Properties {
     val eab = if (isRight) rightInt.asRight[String] else leftString.asLeft[Int]
 
     import effectie.ce2.fx.ioFx
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     runLog[IO](eab).unsafeRunSync()
 
     val expected = eab match {
@@ -435,7 +435,7 @@ object syntaxSpec extends Properties {
     val eab = if (isRight) rightInt.asRight[String] else leftString.asLeft[Int]
 
     import effectie.ce2.fx.ioFx
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     runLog[IO](eab).unsafeRunSync()
 
     val expected = eab match {
@@ -474,7 +474,7 @@ object syntaxSpec extends Properties {
     } yield ()).value
 
     import effectie.ce2.fx.ioFx
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     runLog[IO](logMsg).unsafeRunSync()
 
     val expected = logMsg match {
@@ -513,7 +513,7 @@ object syntaxSpec extends Properties {
     } yield ()).value
 
     import effectie.ce2.fx.ioFx
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     runLog[IO](logMsg).unsafeRunSync()
 
     val expected = logMsg match {
@@ -552,7 +552,7 @@ object syntaxSpec extends Properties {
     } yield ()).value
 
     import effectie.ce2.fx.ioFx
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     runLog[IO](logMsg).unsafeRunSync()
 
     val expected = logMsg match {
@@ -591,7 +591,7 @@ object syntaxSpec extends Properties {
     } yield ()).value
 
     import effectie.ce2.fx.ioFx
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     runLog[IO](logMsg).unsafeRunSync()
 
     val expected = logMsg match {
@@ -633,7 +633,7 @@ object syntaxSpec extends Properties {
     val eab = if (isRight) rightInt.asRight[String] else leftString.asLeft[Int]
 
     import effectie.ce2.fx.ioFx
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     runLog[IO](eab).unsafeRunSync()
 
     val expected = eab match {
@@ -675,7 +675,7 @@ object syntaxSpec extends Properties {
     val eab = if (isRight) rightInt.asRight[String] else leftString.asLeft[Int]
 
     import effectie.ce2.fx.ioFx
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     runLog[IO](eab).unsafeRunSync()
 
     val expected = eab match {
@@ -717,7 +717,7 @@ object syntaxSpec extends Properties {
     val eab = if (isRight) rightInt.asRight[String] else leftString.asLeft[Int]
 
     import effectie.ce2.fx.ioFx
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     runLog[IO](eab).unsafeRunSync()
 
     val expected = eab match {
@@ -759,7 +759,7 @@ object syntaxSpec extends Properties {
     val eab = if (isRight) rightInt.asRight[String] else leftString.asLeft[Int]
 
     import effectie.ce2.fx.ioFx
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     runLog[IO](eab).unsafeRunSync()
 
     val expected = eab match {
@@ -801,7 +801,7 @@ object syntaxSpec extends Properties {
     val eab = if (isRight) rightInt.asRight[String] else leftString.asLeft[Int]
 
     import effectie.ce2.fx.ioFx
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     runLog[IO](eab).unsafeRunSync()
 
     val expected = eab match {
@@ -844,7 +844,7 @@ object syntaxSpec extends Properties {
         } yield ())
 
       import effectie.ce2.fx.ioFx
-      import loggerf.cats.instances.logF
+      import loggerf.instances.cats.logF
       runLog[IO].unsafeRunSync()
 
       val expected = LoggerForTesting(
@@ -873,7 +873,7 @@ object syntaxSpec extends Properties {
         } yield ().some)
 
       import effectie.ce2.fx.ioFx
-      import loggerf.cats.instances.logF
+      import loggerf.instances.cats.logF
       runLog[IO](logMsg).unsafeRunSync()
 
       val expected = logMsg match {
@@ -912,7 +912,7 @@ object syntaxSpec extends Properties {
         } yield ().some)
 
       import effectie.ce2.fx.ioFx
-      import loggerf.cats.instances.logF
+      import loggerf.instances.cats.logF
       runLog[IO](logMsg).unsafeRunSync()
 
       val expected = logMsg match {
@@ -952,7 +952,7 @@ object syntaxSpec extends Properties {
         } yield ().some)
 
       import effectie.ce2.fx.ioFx
-      import loggerf.cats.instances.logF
+      import loggerf.instances.cats.logF
       runLog[IO](logMsg).unsafeRunSync()
 
       val expected = logMsg match {
@@ -992,7 +992,7 @@ object syntaxSpec extends Properties {
         } yield ().some)
 
       import effectie.ce2.fx.ioFx
-      import loggerf.cats.instances.logF
+      import loggerf.instances.cats.logF
       runLog[IO](logMsg).unsafeRunSync()
 
       val expected = logMsg match {
@@ -1034,7 +1034,7 @@ object syntaxSpec extends Properties {
       val eab = if (isRight) rightInt.asRight[String] else leftString.asLeft[Int]
 
       import effectie.ce2.fx.ioFx
-      import loggerf.cats.instances.logF
+      import loggerf.instances.cats.logF
       runLog[IO](eab).unsafeRunSync()
 
       val expected = eab match {
@@ -1076,7 +1076,7 @@ object syntaxSpec extends Properties {
       val eab = if (isRight) rightInt.asRight[String] else leftString.asLeft[Int]
 
       import effectie.ce2.fx.ioFx
-      import loggerf.cats.instances.logF
+      import loggerf.instances.cats.logF
       runLog[IO](eab).unsafeRunSync()
 
       val expected = eab match {
@@ -1118,7 +1118,7 @@ object syntaxSpec extends Properties {
       val eab = if (isRight) rightInt.asRight[String] else leftString.asLeft[Int]
 
       import effectie.ce2.fx.ioFx
-      import loggerf.cats.instances.logF
+      import loggerf.instances.cats.logF
       runLog[IO](eab).unsafeRunSync()
 
       val expected = eab match {
@@ -1160,7 +1160,7 @@ object syntaxSpec extends Properties {
       val eab = if (isRight) rightInt.asRight[String] else leftString.asLeft[Int]
 
       import effectie.ce2.fx.ioFx
-      import loggerf.cats.instances.logF
+      import loggerf.instances.cats.logF
       runLog[IO](eab).unsafeRunSync()
 
       val expected = eab match {
@@ -1202,7 +1202,7 @@ object syntaxSpec extends Properties {
       val eab = if (isRight) rightInt.asRight[String] else leftString.asLeft[Int]
 
       import effectie.ce2.fx.ioFx
-      import loggerf.cats.instances.logF
+      import loggerf.instances.cats.logF
       runLog[IO](eab).unsafeRunSync()
 
       val expected = eab match {
@@ -1241,7 +1241,7 @@ object syntaxSpec extends Properties {
       } yield ()).value
 
       import effectie.ce2.fx.ioFx
-      import loggerf.cats.instances.logF
+      import loggerf.instances.cats.logF
       runLog[IO](logMsg).unsafeRunSync()
 
       val expected = logMsg match {
@@ -1280,7 +1280,7 @@ object syntaxSpec extends Properties {
       } yield ()).value
 
       import effectie.ce2.fx.ioFx
-      import loggerf.cats.instances.logF
+      import loggerf.instances.cats.logF
       runLog[IO](logMsg).unsafeRunSync()
 
       val expected = logMsg match {
@@ -1319,7 +1319,7 @@ object syntaxSpec extends Properties {
       } yield ()).value
 
       import effectie.ce2.fx.ioFx
-      import loggerf.cats.instances.logF
+      import loggerf.instances.cats.logF
       runLog[IO](logMsg).unsafeRunSync()
 
       val expected = logMsg match {
@@ -1358,7 +1358,7 @@ object syntaxSpec extends Properties {
       } yield ()).value
 
       import effectie.ce2.fx.ioFx
-      import loggerf.cats.instances.logF
+      import loggerf.instances.cats.logF
       runLog[IO](logMsg).unsafeRunSync()
 
       val expected = logMsg match {
@@ -1400,7 +1400,7 @@ object syntaxSpec extends Properties {
       val eab = if (isRight) rightInt.asRight[String] else leftString.asLeft[Int]
 
       import effectie.ce2.fx.ioFx
-      import loggerf.cats.instances.logF
+      import loggerf.instances.cats.logF
       runLog[IO](eab).unsafeRunSync()
 
       val expected = eab match {
@@ -1442,7 +1442,7 @@ object syntaxSpec extends Properties {
       val eab = if (isRight) rightInt.asRight[String] else leftString.asLeft[Int]
 
       import effectie.ce2.fx.ioFx
-      import loggerf.cats.instances.logF
+      import loggerf.instances.cats.logF
       runLog[IO](eab).unsafeRunSync()
 
       val expected = eab match {
@@ -1484,7 +1484,7 @@ object syntaxSpec extends Properties {
       val eab = if (isRight) rightInt.asRight[String] else leftString.asLeft[Int]
 
       import effectie.ce2.fx.ioFx
-      import loggerf.cats.instances.logF
+      import loggerf.instances.cats.logF
       runLog[IO](eab).unsafeRunSync()
 
       val expected = eab match {
@@ -1526,7 +1526,7 @@ object syntaxSpec extends Properties {
       val eab = if (isRight) rightInt.asRight[String] else leftString.asLeft[Int]
 
       import effectie.ce2.fx.ioFx
-      import loggerf.cats.instances.logF
+      import loggerf.instances.cats.logF
       runLog[IO](eab).unsafeRunSync()
 
       val expected = eab match {
@@ -1568,7 +1568,7 @@ object syntaxSpec extends Properties {
       val eab = if (isRight) rightInt.asRight[String] else leftString.asLeft[Int]
 
       import effectie.ce2.fx.ioFx
-      import loggerf.cats.instances.logF
+      import loggerf.instances.cats.logF
       runLog[IO](eab).unsafeRunSync()
 
       val expected = eab match {

--- a/modules/logger-f-cats-effect3/shared/src/test/scala/loggerf/cats/instancesSpec.scala
+++ b/modules/logger-f-cats-effect3/shared/src/test/scala/loggerf/cats/instancesSpec.scala
@@ -59,7 +59,7 @@ object instancesSpec extends Properties {
 
     import CatsEffectRunner._
     import effectie.ce3.fx.ioFx
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     implicit val ticket: Ticker = Ticker(TestContext())
     runLog[IO].completeAs(())
     logger ==== expected
@@ -103,7 +103,7 @@ object instancesSpec extends Properties {
 
     import CatsEffectRunner._
     import effectie.ce3.fx.ioFx
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     implicit val ticket: Ticker = Ticker(TestContext())
     runLog[IO](logMsg).completeThen { _ =>
       logger ==== expected
@@ -147,7 +147,7 @@ object instancesSpec extends Properties {
 
     import CatsEffectRunner._
     import effectie.ce3.fx.ioFx
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     implicit val ticket: Ticker = Ticker(TestContext())
     runLog[IO](logMsg).completeThen { _ =>
       logger ==== expected
@@ -192,7 +192,7 @@ object instancesSpec extends Properties {
 
     import CatsEffectRunner._
     import effectie.ce3.fx.ioFx
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     implicit val ticket: Ticker = Ticker(TestContext())
     runLog[IO](logMsg).completeThen { _ =>
       logger ==== expected
@@ -239,7 +239,7 @@ object instancesSpec extends Properties {
 
     import CatsEffectRunner._
     import effectie.ce3.fx.ioFx
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     implicit val ticket: Ticker = Ticker(TestContext())
     runLog[IO](eab).completeThen { _ =>
       logger ==== expected
@@ -286,7 +286,7 @@ object instancesSpec extends Properties {
 
     import CatsEffectRunner._
     import effectie.ce3.fx.ioFx
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     implicit val ticket: Ticker = Ticker(TestContext())
     runLog[IO](eab).completeThen { _ =>
       logger ==== expected
@@ -333,7 +333,7 @@ object instancesSpec extends Properties {
 
     import CatsEffectRunner._
     import effectie.ce3.fx.ioFx
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     implicit val ticket: Ticker = Ticker(TestContext())
     runLog[IO](eab).completeThen { _ =>
       logger ==== expected

--- a/modules/logger-f-cats-effect3/shared/src/test/scala/loggerf/cats/syntaxSpec.scala
+++ b/modules/logger-f-cats-effect3/shared/src/test/scala/loggerf/cats/syntaxSpec.scala
@@ -80,7 +80,7 @@ object syntaxSpec extends Properties {
 
     import CatsEffectRunner._
     import effectie.ce3.fx.ioFx
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     implicit val ticket: Ticker = Ticker(TestContext())
     runLog[IO].completeThen { _ =>
       logger ==== expected
@@ -125,7 +125,7 @@ object syntaxSpec extends Properties {
 
     import CatsEffectRunner._
     import effectie.ce3.fx.ioFx
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     implicit val ticket: Ticker = Ticker(TestContext())
     runLog[IO](logMsg).completeThen { _ =>
       logger ==== expected
@@ -169,7 +169,7 @@ object syntaxSpec extends Properties {
 
     import CatsEffectRunner._
     import effectie.ce3.fx.ioFx
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     implicit val ticket: Ticker = Ticker(TestContext())
     runLog[IO](logMsg).completeThen { _ =>
       logger ==== expected
@@ -214,7 +214,7 @@ object syntaxSpec extends Properties {
 
     import CatsEffectRunner._
     import effectie.ce3.fx.ioFx
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     implicit val ticket: Ticker = Ticker(TestContext())
     runLog[IO](logMsg).completeThen { _ =>
       logger ==== expected
@@ -261,7 +261,7 @@ object syntaxSpec extends Properties {
 
     import CatsEffectRunner._
     import effectie.ce3.fx.ioFx
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     implicit val ticket: Ticker = Ticker(TestContext())
     runLog[IO](eab).completeThen { _ =>
       logger ==== expected
@@ -308,7 +308,7 @@ object syntaxSpec extends Properties {
 
     import CatsEffectRunner._
     import effectie.ce3.fx.ioFx
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     implicit val ticket: Ticker = Ticker(TestContext())
     runLog[IO](eab).completeThen { _ =>
       logger ==== expected
@@ -355,7 +355,7 @@ object syntaxSpec extends Properties {
 
     import CatsEffectRunner._
     import effectie.ce3.fx.ioFx
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     implicit val ticket: Ticker = Ticker(TestContext())
     runLog[IO](eab).completeThen { _ =>
       logger ==== expected
@@ -399,7 +399,7 @@ object syntaxSpec extends Properties {
 
     import CatsEffectRunner._
     import effectie.ce3.fx.ioFx
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     implicit val ticket: Ticker = Ticker(TestContext())
     runLog[IO](logMsg).completeThen { _ =>
       logger ==== expected
@@ -443,7 +443,7 @@ object syntaxSpec extends Properties {
 
     import CatsEffectRunner._
     import effectie.ce3.fx.ioFx
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     implicit val ticket: Ticker = Ticker(TestContext())
     runLog[IO](logMsg).completeThen { _ =>
       logger ==== expected
@@ -487,7 +487,7 @@ object syntaxSpec extends Properties {
 
     import CatsEffectRunner._
     import effectie.ce3.fx.ioFx
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     implicit val ticket: Ticker = Ticker(TestContext())
     runLog[IO](logMsg).completeThen { _ =>
       logger ==== expected
@@ -534,7 +534,7 @@ object syntaxSpec extends Properties {
 
     import CatsEffectRunner._
     import effectie.ce3.fx.ioFx
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     implicit val ticket: Ticker = Ticker(TestContext())
     runLog[IO](eab).completeThen { _ =>
       logger ==== expected
@@ -581,7 +581,7 @@ object syntaxSpec extends Properties {
 
     import CatsEffectRunner._
     import effectie.ce3.fx.ioFx
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     implicit val ticket: Ticker = Ticker(TestContext())
     runLog[IO](eab).completeThen { _ =>
       logger ==== expected
@@ -628,7 +628,7 @@ object syntaxSpec extends Properties {
 
     import CatsEffectRunner._
     import effectie.ce3.fx.ioFx
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     implicit val ticket: Ticker = Ticker(TestContext())
     runLog[IO](eab).completeThen { _ =>
       logger ==== expected
@@ -665,7 +665,7 @@ object syntaxSpec extends Properties {
 
       import CatsEffectRunner._
       import effectie.ce3.fx.ioFx
-      import loggerf.cats.instances.logF
+      import loggerf.instances.cats.logF
       implicit val ticket: Ticker = Ticker(TestContext())
       runLog[IO].completeThen { _ =>
         logger ==== expected
@@ -710,7 +710,7 @@ object syntaxSpec extends Properties {
 
       import CatsEffectRunner._
       import effectie.ce3.fx.ioFx
-      import loggerf.cats.instances.logF
+      import loggerf.instances.cats.logF
       implicit val ticket: Ticker = Ticker(TestContext())
       runLog[IO](logMsg).completeThen { _ =>
         logger ==== expected
@@ -754,7 +754,7 @@ object syntaxSpec extends Properties {
 
       import CatsEffectRunner._
       import effectie.ce3.fx.ioFx
-      import loggerf.cats.instances.logF
+      import loggerf.instances.cats.logF
       implicit val ticket: Ticker = Ticker(TestContext())
       runLog[IO](logMsg).completeThen { _ =>
         logger ==== expected
@@ -799,7 +799,7 @@ object syntaxSpec extends Properties {
 
       import CatsEffectRunner._
       import effectie.ce3.fx.ioFx
-      import loggerf.cats.instances.logF
+      import loggerf.instances.cats.logF
       implicit val ticket: Ticker = Ticker(TestContext())
       runLog[IO](logMsg).completeThen { _ =>
         logger ==== expected
@@ -846,7 +846,7 @@ object syntaxSpec extends Properties {
 
       import CatsEffectRunner._
       import effectie.ce3.fx.ioFx
-      import loggerf.cats.instances.logF
+      import loggerf.instances.cats.logF
       implicit val ticket: Ticker = Ticker(TestContext())
       runLog[IO](eab).completeThen { _ =>
         logger ==== expected
@@ -893,7 +893,7 @@ object syntaxSpec extends Properties {
 
       import CatsEffectRunner._
       import effectie.ce3.fx.ioFx
-      import loggerf.cats.instances.logF
+      import loggerf.instances.cats.logF
       implicit val ticket: Ticker = Ticker(TestContext())
       runLog[IO](eab).completeThen { _ =>
         logger ==== expected
@@ -940,7 +940,7 @@ object syntaxSpec extends Properties {
 
       import CatsEffectRunner._
       import effectie.ce3.fx.ioFx
-      import loggerf.cats.instances.logF
+      import loggerf.instances.cats.logF
       implicit val ticket: Ticker = Ticker(TestContext())
       runLog[IO](eab).completeThen { _ =>
         logger ==== expected
@@ -984,7 +984,7 @@ object syntaxSpec extends Properties {
 
       import CatsEffectRunner._
       import effectie.ce3.fx.ioFx
-      import loggerf.cats.instances.logF
+      import loggerf.instances.cats.logF
       implicit val ticket: Ticker = Ticker(TestContext())
       runLog[IO](logMsg).completeThen { _ =>
         logger ==== expected
@@ -1028,7 +1028,7 @@ object syntaxSpec extends Properties {
 
       import CatsEffectRunner._
       import effectie.ce3.fx.ioFx
-      import loggerf.cats.instances.logF
+      import loggerf.instances.cats.logF
       implicit val ticket: Ticker = Ticker(TestContext())
       runLog[IO](logMsg).completeThen { _ =>
         logger ==== expected
@@ -1072,7 +1072,7 @@ object syntaxSpec extends Properties {
 
       import CatsEffectRunner._
       import effectie.ce3.fx.ioFx
-      import loggerf.cats.instances.logF
+      import loggerf.instances.cats.logF
       implicit val ticket: Ticker = Ticker(TestContext())
       runLog[IO](logMsg).completeThen { _ =>
         logger ==== expected
@@ -1119,7 +1119,7 @@ object syntaxSpec extends Properties {
 
       import CatsEffectRunner._
       import effectie.ce3.fx.ioFx
-      import loggerf.cats.instances.logF
+      import loggerf.instances.cats.logF
       implicit val ticket: Ticker = Ticker(TestContext())
       runLog[IO](eab).completeThen { _ =>
         logger ==== expected
@@ -1166,7 +1166,7 @@ object syntaxSpec extends Properties {
 
       import CatsEffectRunner._
       import effectie.ce3.fx.ioFx
-      import loggerf.cats.instances.logF
+      import loggerf.instances.cats.logF
       implicit val ticket: Ticker = Ticker(TestContext())
       runLog[IO](eab).completeThen { _ =>
         logger ==== expected
@@ -1213,7 +1213,7 @@ object syntaxSpec extends Properties {
 
       import CatsEffectRunner._
       import effectie.ce3.fx.ioFx
-      import loggerf.cats.instances.logF
+      import loggerf.instances.cats.logF
       implicit val ticket: Ticker = Ticker(TestContext())
       runLog[IO](eab).completeThen { _ =>
         logger ==== expected

--- a/modules/logger-f-cats/shared/src/main/scala-2/loggerf/instances/cats.scala
+++ b/modules/logger-f-cats/shared/src/main/scala-2/loggerf/instances/cats.scala
@@ -1,6 +1,6 @@
-package loggerf.cats
+package loggerf.instances
 
-import cats.Monad
+import _root_.cats.Monad
 import effectie.core.FxCtor
 import loggerf.core.Log
 import loggerf.logger.CanLog
@@ -8,8 +8,8 @@ import loggerf.logger.CanLog
 /** @author Kevin Lee
   * @since 2020-04-10
   */
-trait instances {
-  import instances._
+trait cats {
+  import cats._
 
   @SuppressWarnings(Array("org.wartremover.warts.ImplicitParameter"))
   implicit def logF[F[*]](
@@ -21,7 +21,7 @@ trait instances {
 
 }
 
-object instances extends instances {
+object cats extends cats {
 
   @SuppressWarnings(Array("org.wartremover.warts.ImplicitParameter"))
   final class LogF[F[*]](

--- a/modules/logger-f-cats/shared/src/main/scala-3/loggerf/instances/cats.scala
+++ b/modules/logger-f-cats/shared/src/main/scala-3/loggerf/instances/cats.scala
@@ -1,6 +1,6 @@
-package loggerf.cats
+package loggerf.instances
 
-import cats.Monad
+import _root_.cats.Monad
 import effectie.core.FxCtor
 import loggerf.core.Log
 import loggerf.logger.CanLog
@@ -8,7 +8,7 @@ import loggerf.logger.CanLog
 /** @author Kevin Lee
   * @since 2020-04-10
   */
-trait instances {
+trait cats {
 
   given logF[F[*]](
     using EF: FxCtor[F],
@@ -27,4 +27,4 @@ trait instances {
 
 }
 
-object instances extends instances
+object cats extends cats

--- a/modules/logger-f-monix/shared/src/test/scala/loggerf/monix/instancesSpec.scala
+++ b/modules/logger-f-monix/shared/src/test/scala/loggerf/monix/instancesSpec.scala
@@ -45,7 +45,7 @@ object instancesSpec extends Properties {
       } yield ())
 
     import effectie.monix3.fx._
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     runLog[Task].runSyncUnsafe()
 
     val expected = LoggerForTesting(
@@ -74,7 +74,7 @@ object instancesSpec extends Properties {
       } yield ().some)
 
     import effectie.monix3.fx._
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     runLog[Task](logMsg).runSyncUnsafe()
 
     val expected = logMsg match {
@@ -113,7 +113,7 @@ object instancesSpec extends Properties {
       } yield ().some)
 
     import effectie.monix3.fx._
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     runLog[Task](logMsg).runSyncUnsafe()
 
     val expected = logMsg match {
@@ -153,7 +153,7 @@ object instancesSpec extends Properties {
       } yield ().some)
 
     import effectie.monix3.fx._
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     runLog[Task](logMsg).runSyncUnsafe()
 
     val expected = logMsg match {
@@ -195,7 +195,7 @@ object instancesSpec extends Properties {
     val eab = if (isRight) rightInt.asRight[String] else leftString.asLeft[Int]
 
     import effectie.monix3.fx._
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     runLog[Task](eab).runSyncUnsafe()
 
     val expected = eab match {
@@ -237,7 +237,7 @@ object instancesSpec extends Properties {
     val eab = if (isRight) rightInt.asRight[String] else leftString.asLeft[Int]
 
     import effectie.monix3.fx._
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     runLog[Task](eab).runSyncUnsafe()
 
     val expected = eab match {
@@ -279,7 +279,7 @@ object instancesSpec extends Properties {
     val eab = if (isRight) rightInt.asRight[String] else leftString.asLeft[Int]
 
     import effectie.monix3.fx._
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     runLog[Task](eab).runSyncUnsafe()
 
     val expected = eab match {

--- a/modules/logger-f-monix/shared/src/test/scala/loggerf/monix/syntaxSpec.scala
+++ b/modules/logger-f-monix/shared/src/test/scala/loggerf/monix/syntaxSpec.scala
@@ -66,7 +66,7 @@ object syntaxSpec extends Properties {
       } yield ())
 
     import effectie.monix3.fx._
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     runLog[Task].runSyncUnsafe()
 
     val expected = LoggerForTesting(
@@ -95,7 +95,7 @@ object syntaxSpec extends Properties {
       } yield ().some)
 
     import effectie.monix3.fx._
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     runLog[Task](logMsg).runSyncUnsafe()
 
     val expected = logMsg match {
@@ -134,7 +134,7 @@ object syntaxSpec extends Properties {
       } yield ().some)
 
     import effectie.monix3.fx._
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     runLog[Task](logMsg).runSyncUnsafe()
 
     val expected = logMsg match {
@@ -174,7 +174,7 @@ object syntaxSpec extends Properties {
       } yield ().some)
 
     import effectie.monix3.fx._
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     runLog[Task](logMsg).runSyncUnsafe()
 
     val expected = logMsg match {
@@ -216,7 +216,7 @@ object syntaxSpec extends Properties {
     val eab = if (isRight) rightInt.asRight[String] else leftString.asLeft[Int]
 
     import effectie.monix3.fx._
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     runLog[Task](eab).runSyncUnsafe()
 
     val expected = eab match {
@@ -258,7 +258,7 @@ object syntaxSpec extends Properties {
     val eab = if (isRight) rightInt.asRight[String] else leftString.asLeft[Int]
 
     import effectie.monix3.fx._
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     runLog[Task](eab).runSyncUnsafe()
 
     val expected = eab match {
@@ -300,7 +300,7 @@ object syntaxSpec extends Properties {
     val eab = if (isRight) rightInt.asRight[String] else leftString.asLeft[Int]
 
     import effectie.monix3.fx._
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     runLog[Task](eab).runSyncUnsafe()
 
     val expected = eab match {
@@ -339,7 +339,7 @@ object syntaxSpec extends Properties {
     } yield ()).value
 
     import effectie.monix3.fx._
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     runLog[Task](logMsg).runSyncUnsafe()
 
     val expected = logMsg match {
@@ -378,7 +378,7 @@ object syntaxSpec extends Properties {
     } yield ()).value
 
     import effectie.monix3.fx._
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     runLog[Task](logMsg).runSyncUnsafe()
 
     val expected = logMsg match {
@@ -417,7 +417,7 @@ object syntaxSpec extends Properties {
     } yield ()).value
 
     import effectie.monix3.fx._
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     runLog[Task](logMsg).runSyncUnsafe()
 
     val expected = logMsg match {
@@ -459,7 +459,7 @@ object syntaxSpec extends Properties {
     val eab = if (isRight) rightInt.asRight[String] else leftString.asLeft[Int]
 
     import effectie.monix3.fx._
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     runLog[Task](eab).runSyncUnsafe()
 
     val expected = eab match {
@@ -501,7 +501,7 @@ object syntaxSpec extends Properties {
     val eab = if (isRight) rightInt.asRight[String] else leftString.asLeft[Int]
 
     import effectie.monix3.fx._
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     runLog[Task](eab).runSyncUnsafe()
 
     val expected = eab match {
@@ -543,7 +543,7 @@ object syntaxSpec extends Properties {
     val eab = if (isRight) rightInt.asRight[String] else leftString.asLeft[Int]
 
     import effectie.monix3.fx._
-    import loggerf.cats.instances.logF
+    import loggerf.instances.cats.logF
     runLog[Task](eab).runSyncUnsafe()
 
     val expected = eab match {
@@ -586,7 +586,7 @@ object syntaxSpec extends Properties {
         } yield ())
 
       import effectie.monix3.fx._
-      import loggerf.cats.instances.logF
+      import loggerf.instances.cats.logF
       runLog[Task].runSyncUnsafe()
 
       val expected = LoggerForTesting(
@@ -615,7 +615,7 @@ object syntaxSpec extends Properties {
         } yield ().some)
 
       import effectie.monix3.fx._
-      import loggerf.cats.instances.logF
+      import loggerf.instances.cats.logF
       runLog[Task](logMsg).runSyncUnsafe()
 
       val expected = logMsg match {
@@ -654,7 +654,7 @@ object syntaxSpec extends Properties {
         } yield ().some)
 
       import effectie.monix3.fx._
-      import loggerf.cats.instances.logF
+      import loggerf.instances.cats.logF
       runLog[Task](logMsg).runSyncUnsafe()
 
       val expected = logMsg match {
@@ -694,7 +694,7 @@ object syntaxSpec extends Properties {
         } yield ().some)
 
       import effectie.monix3.fx._
-      import loggerf.cats.instances.logF
+      import loggerf.instances.cats.logF
       runLog[Task](logMsg).runSyncUnsafe()
 
       val expected = logMsg match {
@@ -736,7 +736,7 @@ object syntaxSpec extends Properties {
       val eab = if (isRight) rightInt.asRight[String] else leftString.asLeft[Int]
 
       import effectie.monix3.fx._
-      import loggerf.cats.instances.logF
+      import loggerf.instances.cats.logF
       runLog[Task](eab).runSyncUnsafe()
 
       val expected = eab match {
@@ -778,7 +778,7 @@ object syntaxSpec extends Properties {
       val eab = if (isRight) rightInt.asRight[String] else leftString.asLeft[Int]
 
       import effectie.monix3.fx._
-      import loggerf.cats.instances.logF
+      import loggerf.instances.cats.logF
       runLog[Task](eab).runSyncUnsafe()
 
       val expected = eab match {
@@ -820,7 +820,7 @@ object syntaxSpec extends Properties {
       val eab = if (isRight) rightInt.asRight[String] else leftString.asLeft[Int]
 
       import effectie.monix3.fx._
-      import loggerf.cats.instances.logF
+      import loggerf.instances.cats.logF
       runLog[Task](eab).runSyncUnsafe()
 
       val expected = eab match {
@@ -859,7 +859,7 @@ object syntaxSpec extends Properties {
       } yield ()).value
 
       import effectie.monix3.fx._
-      import loggerf.cats.instances.logF
+      import loggerf.instances.cats.logF
       runLog[Task](logMsg).runSyncUnsafe()
 
       val expected = logMsg match {
@@ -898,7 +898,7 @@ object syntaxSpec extends Properties {
       } yield ()).value
 
       import effectie.monix3.fx._
-      import loggerf.cats.instances.logF
+      import loggerf.instances.cats.logF
       runLog[Task](logMsg).runSyncUnsafe()
 
       val expected = logMsg match {
@@ -937,7 +937,7 @@ object syntaxSpec extends Properties {
       } yield ()).value
 
       import effectie.monix3.fx._
-      import loggerf.cats.instances.logF
+      import loggerf.instances.cats.logF
       runLog[Task](logMsg).runSyncUnsafe()
 
       val expected = logMsg match {
@@ -979,7 +979,7 @@ object syntaxSpec extends Properties {
       val eab = if (isRight) rightInt.asRight[String] else leftString.asLeft[Int]
 
       import effectie.monix3.fx._
-      import loggerf.cats.instances.logF
+      import loggerf.instances.cats.logF
       runLog[Task](eab).runSyncUnsafe()
 
       val expected = eab match {
@@ -1021,7 +1021,7 @@ object syntaxSpec extends Properties {
       val eab = if (isRight) rightInt.asRight[String] else leftString.asLeft[Int]
 
       import effectie.monix3.fx._
-      import loggerf.cats.instances.logF
+      import loggerf.instances.cats.logF
       runLog[Task](eab).runSyncUnsafe()
 
       val expected = eab match {
@@ -1063,7 +1063,7 @@ object syntaxSpec extends Properties {
       val eab = if (isRight) rightInt.asRight[String] else leftString.asLeft[Int]
 
       import effectie.monix3.fx._
-      import loggerf.cats.instances.logF
+      import loggerf.instances.cats.logF
       runLog[Task](eab).runSyncUnsafe()
 
       val expected = eab match {


### PR DESCRIPTION
# Summary
Close #321 - Move `loggerf.cats.instances.logF` to `loggerf.instances.cats`