### PR TITLE
Close #322 - Change loggerf.cats.syntax to loggerf.syntax

### DIFF
--- a/modules/logger-f-cats-effect/shared/src/test/scala/loggerf/cats/instancesSpec.scala
+++ b/modules/logger-f-cats-effect/shared/src/test/scala/loggerf/cats/instancesSpec.scala
@@ -7,7 +7,7 @@ import effectie.core.FxCtor
 import effectie.syntax.all._
 import hedgehog._
 import hedgehog.runner._
-import loggerf.cats.syntax.all._
+import loggerf.syntax.all._
 import loggerf.core._
 import loggerf.logger._
 

--- a/modules/logger-f-cats-effect/shared/src/test/scala/loggerf/cats/syntaxSpec.scala
+++ b/modules/logger-f-cats-effect/shared/src/test/scala/loggerf/cats/syntaxSpec.scala
@@ -9,7 +9,7 @@ import effectie.syntax.all._
 import hedgehog._
 import hedgehog.runner._
 import loggerf.core.Log
-import loggerf.cats.syntax.all._
+import loggerf.syntax.all._
 import loggerf.logger._
 
 /** @author Kevin Lee

--- a/modules/logger-f-cats-effect3/shared/src/test/scala/loggerf/cats/instancesSpec.scala
+++ b/modules/logger-f-cats-effect3/shared/src/test/scala/loggerf/cats/instancesSpec.scala
@@ -10,7 +10,7 @@ import extras.concurrent.testing.ConcurrentSupport
 import extras.hedgehog.cats.effect.CatsEffectRunner
 import hedgehog._
 import hedgehog.runner._
-import loggerf.cats.syntax.all._
+import loggerf.syntax.all._
 import loggerf.core._
 import loggerf.logger.LoggerForTesting
 

--- a/modules/logger-f-cats-effect3/shared/src/test/scala/loggerf/cats/syntaxSpec.scala
+++ b/modules/logger-f-cats-effect3/shared/src/test/scala/loggerf/cats/syntaxSpec.scala
@@ -11,7 +11,7 @@ import extras.concurrent.testing.ConcurrentSupport
 import extras.hedgehog.cats.effect.CatsEffectRunner
 import hedgehog._
 import hedgehog.runner._
-import loggerf.cats.syntax.all._
+import loggerf.syntax.all._
 import loggerf.core.Log
 import loggerf.logger.LoggerForTesting
 

--- a/modules/logger-f-cats/shared/src/main/scala-2/loggerf/cats/syntax/all.scala
+++ b/modules/logger-f-cats/shared/src/main/scala-2/loggerf/cats/syntax/all.scala
@@ -1,6 +1,0 @@
-package loggerf.cats.syntax
-
-/** @author Kevin Lee
-  * @since 2022-02-20
-  */
-object all extends LogMessageSyntax with LogSyntax

--- a/modules/logger-f-cats/shared/src/main/scala-2/loggerf/syntax/LogMessageSyntax.scala
+++ b/modules/logger-f-cats/shared/src/main/scala-2/loggerf/syntax/LogMessageSyntax.scala
@@ -1,4 +1,4 @@
-package loggerf.cats.syntax
+package loggerf.syntax
 
 /** @author Kevin Lee
   * @since 2022-02-20

--- a/modules/logger-f-cats/shared/src/main/scala-2/loggerf/syntax/LogSyntax.scala
+++ b/modules/logger-f-cats/shared/src/main/scala-2/loggerf/syntax/LogSyntax.scala
@@ -1,4 +1,4 @@
-package loggerf.cats.syntax
+package loggerf.syntax
 
 import _root_.cats.data.{EitherT, OptionT}
 import loggerf.LogMessage

--- a/modules/logger-f-cats/shared/src/main/scala-2/loggerf/syntax/all.scala
+++ b/modules/logger-f-cats/shared/src/main/scala-2/loggerf/syntax/all.scala
@@ -1,0 +1,7 @@
+package loggerf.syntax
+
+/** @author Kevin Lee
+  * @since 2022-02-20
+  */
+trait all extends logging
+object all extends all

--- a/modules/logger-f-cats/shared/src/main/scala-2/loggerf/syntax/logging.scala
+++ b/modules/logger-f-cats/shared/src/main/scala-2/loggerf/syntax/logging.scala
@@ -1,0 +1,7 @@
+package loggerf.syntax
+
+/** @author Kevin Lee
+  * @since 2022-09-23
+  */
+trait logging extends LogMessageSyntax with LogSyntax
+object logging extends logging

--- a/modules/logger-f-cats/shared/src/main/scala-3/loggerf/cats/syntax/all.scala
+++ b/modules/logger-f-cats/shared/src/main/scala-3/loggerf/cats/syntax/all.scala
@@ -1,3 +1,0 @@
-package loggerf.cats.syntax
-
-object all extends LogMessageSyntax with LogSyntax

--- a/modules/logger-f-cats/shared/src/main/scala-3/loggerf/syntax/LogMessageSyntax.scala
+++ b/modules/logger-f-cats/shared/src/main/scala-3/loggerf/syntax/LogMessageSyntax.scala
@@ -1,4 +1,4 @@
-package loggerf.cats.syntax
+package loggerf.syntax
 
 /** @author Kevin Lee
   * @since 2022-02-20

--- a/modules/logger-f-cats/shared/src/main/scala-3/loggerf/syntax/LogSyntax.scala
+++ b/modules/logger-f-cats/shared/src/main/scala-3/loggerf/syntax/LogSyntax.scala
@@ -1,4 +1,4 @@
-package loggerf.cats.syntax
+package loggerf.syntax
 
 import cats.data.{EitherT, OptionT}
 import loggerf.LeveledMessage

--- a/modules/logger-f-cats/shared/src/main/scala-3/loggerf/syntax/all.scala
+++ b/modules/logger-f-cats/shared/src/main/scala-3/loggerf/syntax/all.scala
@@ -1,0 +1,4 @@
+package loggerf.syntax
+
+trait all extends logging
+object all extends all

--- a/modules/logger-f-cats/shared/src/main/scala-3/loggerf/syntax/logging.scala
+++ b/modules/logger-f-cats/shared/src/main/scala-3/loggerf/syntax/logging.scala
@@ -1,0 +1,7 @@
+package loggerf.syntax
+
+/** @author Kevin Lee
+  * @since 2022-09-23
+  */
+trait logging extends LogMessageSyntax with LogSyntax
+object logging extends logging

--- a/modules/logger-f-cats/shared/src/test/scala/loggerf/future/syntaxSpec.scala
+++ b/modules/logger-f-cats/shared/src/test/scala/loggerf/future/syntaxSpec.scala
@@ -12,7 +12,7 @@ import extras.concurrent.testing.ConcurrentSupport
 import extras.concurrent.testing.types.{ErrorLogger, WaitFor}
 import hedgehog._
 import hedgehog.runner._
-import loggerf.cats.syntax.all._
+import loggerf.syntax.all._
 import loggerf.core.Log
 import loggerf.logger._
 

--- a/modules/logger-f-core/shared/src/main/scala-3/loggerf/core/Log.scala
+++ b/modules/logger-f-core/shared/src/main/scala-3/loggerf/core/Log.scala
@@ -48,7 +48,6 @@ trait Log[F[*]] {
         }
     }
 
-
   def log[A, B](
     feab: F[Either[A, B]]
   )(
@@ -73,7 +72,6 @@ trait Log[F[*]] {
             EF.pureOf(Right(r))
         }
     }
-
 
 }
 

--- a/modules/logger-f-monix/shared/src/test/scala/loggerf/monix/instancesSpec.scala
+++ b/modules/logger-f-monix/shared/src/test/scala/loggerf/monix/instancesSpec.scala
@@ -6,7 +6,7 @@ import effectie.core.FxCtor
 import effectie.syntax.all._
 import hedgehog._
 import hedgehog.runner._
-import loggerf.cats.syntax.all._
+import loggerf.syntax.all._
 import loggerf.core.Log
 import loggerf.logger.LoggerForTesting
 import monix.eval.Task

--- a/modules/logger-f-monix/shared/src/test/scala/loggerf/monix/syntaxSpec.scala
+++ b/modules/logger-f-monix/shared/src/test/scala/loggerf/monix/syntaxSpec.scala
@@ -7,7 +7,7 @@ import effectie.core.FxCtor
 import effectie.syntax.all._
 import hedgehog._
 import hedgehog.runner._
-import loggerf.cats.syntax.all._
+import loggerf.syntax.all._
 import loggerf.core.Log
 import loggerf.logger.LoggerForTesting
 import monix.eval.Task


### PR DESCRIPTION
# Summary
Close #322 - Change `loggerf.cats.syntax` to `loggerf.syntax`