### PR TITLE
Close #329 - loggerf.future.instances.logFuture => loggerf.instances.future.logFuture

### DIFF
--- a/modules/logger-f-cats/shared/src/test/scala/loggerf/instances/instancesSpec.scala
+++ b/modules/logger-f-cats/shared/src/test/scala/loggerf/instances/instancesSpec.scala
@@ -1,10 +1,10 @@
-package loggerf.future
+package loggerf.instances
 
-import cats.Monad
-import cats.syntax.either._
-import cats.syntax.flatMap._
-import cats.syntax.functor._
-import cats.syntax.option._
+import _root_.cats.Monad
+import _root_.cats.syntax.either._
+import _root_.cats.syntax.flatMap._
+import _root_.cats.syntax.functor._
+import _root_.cats.syntax.option._
 import effectie.core._
 import effectie.syntax.all._
 import extras.concurrent.testing.ConcurrentSupport
@@ -13,7 +13,7 @@ import hedgehog._
 import hedgehog.runner._
 import loggerf.core._
 import loggerf.core.syntax.all._
-import loggerf.future.instances.logFuture
+import loggerf.instances.future.logFuture
 import loggerf.logger._
 
 import java.util.concurrent.ExecutorService

--- a/modules/logger-f-cats/shared/src/test/scala/loggerf/instances/showSpec.scala
+++ b/modules/logger-f-cats/shared/src/test/scala/loggerf/instances/showSpec.scala
@@ -1,14 +1,15 @@
-package loggerf.cats
+package loggerf.instances
 
-import cats._
-import cats.syntax.all._
+import _root_.cats._
+import _root_.cats.syntax.all._
 import effectie.core.FxCtor
 import effectie.syntax.all._
 import hedgehog._
 import hedgehog.runner._
 import loggerf.core._
-import loggerf.core.syntax.all._
+import loggerf.instances.show.showToLog
 import loggerf.logger.LoggerForTesting
+import loggerf.syntax.all._
 
 /** @author Kevin Lee
   * @since 2022-02-20
@@ -31,8 +32,6 @@ object showSpec extends Properties {
   } yield {
 
     val logger: LoggerForTesting = LoggerForTesting()
-
-    import loggerf.instances.show.showToLog
 
     def runLog[F[*]: Log: FxCtor: Monad]: F[Unit] =
       for {

--- a/modules/logger-f-cats/shared/src/test/scala/loggerf/instances/syntaxSpec.scala
+++ b/modules/logger-f-cats/shared/src/test/scala/loggerf/instances/syntaxSpec.scala
@@ -1,11 +1,11 @@
-package loggerf.future
+package loggerf.instances
 
-import cats.Monad
-import cats.data.{EitherT, OptionT}
-import cats.syntax.either._
-import cats.syntax.flatMap._
-import cats.syntax.functor._
-import cats.syntax.option._
+import _root_.cats.Monad
+import _root_.cats.data.{EitherT, OptionT}
+import _root_.cats.syntax.either._
+import _root_.cats.syntax.flatMap._
+import _root_.cats.syntax.functor._
+import _root_.cats.syntax.option._
 import effectie.core.FxCtor
 import effectie.syntax.all._
 import extras.concurrent.testing.ConcurrentSupport
@@ -87,7 +87,7 @@ object syntaxSpec extends Properties {
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
     ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
-      import loggerf.future.instances.logFuture
+      import loggerf.instances.future.logFuture
       runLog[Future]
     }
 
@@ -132,7 +132,7 @@ object syntaxSpec extends Properties {
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
     ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
-      import loggerf.future.instances.logFuture
+      import loggerf.instances.future.logFuture
       runLog[Future](logMsg)
     }
 
@@ -176,7 +176,7 @@ object syntaxSpec extends Properties {
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
     ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
-      import loggerf.future.instances.logFuture
+      import loggerf.instances.future.logFuture
       runLog[Future](logMsg)
     }
 
@@ -221,7 +221,7 @@ object syntaxSpec extends Properties {
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
     ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
-      import loggerf.future.instances.logFuture
+      import loggerf.instances.future.logFuture
       runLog[Future](logMsg)
     }
 
@@ -268,7 +268,7 @@ object syntaxSpec extends Properties {
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
     ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
-      import loggerf.future.instances.logFuture
+      import loggerf.instances.future.logFuture
       runLog[Future](eab)
     }
 
@@ -315,7 +315,7 @@ object syntaxSpec extends Properties {
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
     ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
-      import loggerf.future.instances.logFuture
+      import loggerf.instances.future.logFuture
       runLog[Future](eab)
     }
 
@@ -362,7 +362,7 @@ object syntaxSpec extends Properties {
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
     ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
-      import loggerf.future.instances.logFuture
+      import loggerf.instances.future.logFuture
       runLog[Future](eab)
     }
 
@@ -406,7 +406,7 @@ object syntaxSpec extends Properties {
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
     ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
-      import loggerf.future.instances.logFuture
+      import loggerf.instances.future.logFuture
       runLog[Future](logMsg)
     }
 
@@ -450,7 +450,7 @@ object syntaxSpec extends Properties {
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
     ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
-      import loggerf.future.instances.logFuture
+      import loggerf.instances.future.logFuture
       runLog[Future](logMsg)
     }
 
@@ -494,7 +494,7 @@ object syntaxSpec extends Properties {
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
     ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
-      import loggerf.future.instances.logFuture
+      import loggerf.instances.future.logFuture
       runLog[Future](logMsg)
     }
 
@@ -541,7 +541,7 @@ object syntaxSpec extends Properties {
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
     ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
-      import loggerf.future.instances.logFuture
+      import loggerf.instances.future.logFuture
       runLog[Future](eab)
     }
 
@@ -588,7 +588,7 @@ object syntaxSpec extends Properties {
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
     ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
-      import loggerf.future.instances.logFuture
+      import loggerf.instances.future.logFuture
       runLog[Future](eab)
     }
 
@@ -635,7 +635,7 @@ object syntaxSpec extends Properties {
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
     ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
-      import loggerf.future.instances.logFuture
+      import loggerf.instances.future.logFuture
       runLog[Future](eab)
     }
 
@@ -675,7 +675,7 @@ object syntaxSpec extends Properties {
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
       ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
-        import loggerf.future.instances.logFuture
+        import loggerf.instances.future.logFuture
         runLog[Future]
       }
 
@@ -720,7 +720,7 @@ object syntaxSpec extends Properties {
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
       ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
-        import loggerf.future.instances.logFuture
+        import loggerf.instances.future.logFuture
         runLog[Future](logMsg)
       }
 
@@ -764,7 +764,7 @@ object syntaxSpec extends Properties {
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
       ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
-        import loggerf.future.instances.logFuture
+        import loggerf.instances.future.logFuture
         runLog[Future](logMsg)
       }
 
@@ -809,7 +809,7 @@ object syntaxSpec extends Properties {
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
       ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
-        import loggerf.future.instances.logFuture
+        import loggerf.instances.future.logFuture
         runLog[Future](logMsg)
       }
 
@@ -856,7 +856,7 @@ object syntaxSpec extends Properties {
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
       ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
-        import loggerf.future.instances.logFuture
+        import loggerf.instances.future.logFuture
         runLog[Future](eab)
       }
 
@@ -903,7 +903,7 @@ object syntaxSpec extends Properties {
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
       ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
-        import loggerf.future.instances.logFuture
+        import loggerf.instances.future.logFuture
         runLog[Future](eab)
       }
 
@@ -950,7 +950,7 @@ object syntaxSpec extends Properties {
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
       ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
-        import loggerf.future.instances.logFuture
+        import loggerf.instances.future.logFuture
         runLog[Future](eab)
       }
 
@@ -994,7 +994,7 @@ object syntaxSpec extends Properties {
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
       ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
-        import loggerf.future.instances.logFuture
+        import loggerf.instances.future.logFuture
         runLog[Future](logMsg)
       }
 
@@ -1038,7 +1038,7 @@ object syntaxSpec extends Properties {
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
       ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
-        import loggerf.future.instances.logFuture
+        import loggerf.instances.future.logFuture
         runLog[Future](logMsg)
       }
 
@@ -1082,7 +1082,7 @@ object syntaxSpec extends Properties {
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
       ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
-        import loggerf.future.instances.logFuture
+        import loggerf.instances.future.logFuture
         runLog[Future](logMsg)
       }
 
@@ -1129,7 +1129,7 @@ object syntaxSpec extends Properties {
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
       ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
-        import loggerf.future.instances.logFuture
+        import loggerf.instances.future.logFuture
         runLog[Future](eab)
       }
 
@@ -1176,7 +1176,7 @@ object syntaxSpec extends Properties {
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
       ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
-        import loggerf.future.instances.logFuture
+        import loggerf.instances.future.logFuture
         runLog[Future](eab)
       }
 
@@ -1223,7 +1223,7 @@ object syntaxSpec extends Properties {
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
       ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
-        import loggerf.future.instances.logFuture
+        import loggerf.instances.future.logFuture
         runLog[Future](eab)
       }
 

--- a/modules/logger-f-core/shared/src/main/scala-2/loggerf/instances/future.scala
+++ b/modules/logger-f-core/shared/src/main/scala-2/loggerf/instances/future.scala
@@ -1,4 +1,4 @@
-package loggerf.future
+package loggerf.instances
 
 import effectie.core.FxCtor
 import loggerf.core.Log
@@ -7,23 +7,25 @@ import loggerf.logger.CanLog
 import scala.concurrent.{ExecutionContext, Future}
 
 /** @author Kevin Lee
-  * @since 2022-02-09
+  * @since 2022-02-08
   */
-object instances {
-
-  given logFuture(
-    using EF: FxCtor[Future],
+object future {
+  @SuppressWarnings(Array("org.wartremover.warts.ImplicitParameter"))
+  implicit def logFuture(
+    implicit EF: FxCtor[Future],
     canLog: CanLog,
     EC: ExecutionContext,
   ): Log[Future] =
     new LogFuture(EF, canLog, EC)
 
+  @SuppressWarnings(Array("org.wartremover.warts.ImplicitParameter"))
   final class LogFuture(
     override val EF: FxCtor[Future],
     override val canLog: CanLog,
     val EC: ExecutionContext,
   ) extends Log[Future] {
-    override def flatMap0[A, B](fa: Future[A])(f: A => Future[B]): Future[B] = fa.flatMap(f)(using EC)
+    override def flatMap0[A, B](fa: Future[A])(f: A => Future[B]): Future[B] =
+      fa.flatMap(f)(EC)
   }
 
 }

--- a/modules/logger-f-core/shared/src/main/scala-3/loggerf/core/syntax/LogSyntax.scala
+++ b/modules/logger-f-core/shared/src/main/scala-3/loggerf/core/syntax/LogSyntax.scala
@@ -3,7 +3,7 @@ package loggerf.core.syntax
 import loggerf.LeveledMessage
 import loggerf.Ignore
 import loggerf.core.Log
-import loggerf.future.instances.given
+import loggerf.instances.future.given
 
 import scala.concurrent.Future
 

--- a/modules/logger-f-core/shared/src/main/scala-3/loggerf/instances/future.scala
+++ b/modules/logger-f-core/shared/src/main/scala-3/loggerf/instances/future.scala
@@ -1,4 +1,4 @@
-package loggerf.future
+package loggerf.instances
 
 import effectie.core.FxCtor
 import loggerf.core.Log
@@ -7,25 +7,23 @@ import loggerf.logger.CanLog
 import scala.concurrent.{ExecutionContext, Future}
 
 /** @author Kevin Lee
-  * @since 2022-02-08
+  * @since 2022-02-09
   */
-object instances {
-  @SuppressWarnings(Array("org.wartremover.warts.ImplicitParameter"))
-  implicit def logFuture(
-    implicit EF: FxCtor[Future],
+object future {
+
+  given logFuture(
+    using EF: FxCtor[Future],
     canLog: CanLog,
     EC: ExecutionContext,
   ): Log[Future] =
     new LogFuture(EF, canLog, EC)
 
-  @SuppressWarnings(Array("org.wartremover.warts.ImplicitParameter"))
   final class LogFuture(
     override val EF: FxCtor[Future],
     override val canLog: CanLog,
     val EC: ExecutionContext,
   ) extends Log[Future] {
-    override def flatMap0[A, B](fa: Future[A])(f: A => Future[B]): Future[B] =
-      fa.flatMap(f)(EC)
+    override def flatMap0[A, B](fa: Future[A])(f: A => Future[B]): Future[B] = fa.flatMap(f)(using EC)
   }
 
 }

--- a/modules/logger-f-core/shared/src/test/scala/loggerf/instances/instancesSpec.scala
+++ b/modules/logger-f-core/shared/src/test/scala/loggerf/instances/instancesSpec.scala
@@ -1,10 +1,7 @@
-package loggerf.future
+package loggerf.instances
 
 import cats.Monad
-import cats.syntax.either._
-import cats.syntax.flatMap._
-import cats.syntax.functor._
-import cats.syntax.option._
+import cats.syntax.all._
 import effectie.core._
 import extras.concurrent.testing.ConcurrentSupport
 import extras.concurrent.testing.types.{ErrorLogger, WaitFor}
@@ -12,7 +9,7 @@ import hedgehog._
 import hedgehog.runner._
 import loggerf.core._
 import loggerf.core.syntax.all._
-import loggerf.future.instances.logFuture
+import loggerf.instances.future.logFuture
 import loggerf.logger._
 
 import java.util.concurrent.ExecutorService

--- a/modules/logger-f-core/shared/src/test/scala/loggerf/instances/syntaxSpec.scala
+++ b/modules/logger-f-core/shared/src/test/scala/loggerf/instances/syntaxSpec.scala
@@ -1,10 +1,7 @@
-package loggerf.future
+package loggerf.instances
 
 import cats.Monad
-import cats.syntax.either._
-import cats.syntax.flatMap._
-import cats.syntax.functor._
-import cats.syntax.option._
+import cats.syntax.all._
 import effectie.core.FxCtor
 import extras.concurrent.testing.ConcurrentSupport
 import extras.concurrent.testing.types.{ErrorLogger, WaitFor}
@@ -73,7 +70,7 @@ object syntaxSpec extends Properties {
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
     ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
-      import loggerf.future.instances.logFuture
+      import loggerf.instances.future.logFuture
       runLog[Future]
     }
 
@@ -118,7 +115,7 @@ object syntaxSpec extends Properties {
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
     ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
-      import loggerf.future.instances.logFuture
+      import loggerf.instances.future.logFuture
       runLog[Future](logMsg)
     }
 
@@ -162,7 +159,7 @@ object syntaxSpec extends Properties {
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
     ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
-      import loggerf.future.instances.logFuture
+      import loggerf.instances.future.logFuture
       runLog[Future](logMsg)
     }
 
@@ -207,7 +204,7 @@ object syntaxSpec extends Properties {
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
     ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
-      import loggerf.future.instances.logFuture
+      import loggerf.instances.future.logFuture
       runLog[Future](logMsg)
     }
 
@@ -254,7 +251,7 @@ object syntaxSpec extends Properties {
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
     ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
-      import loggerf.future.instances.logFuture
+      import loggerf.instances.future.logFuture
       runLog[Future](eab)
     }
 
@@ -301,7 +298,7 @@ object syntaxSpec extends Properties {
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
     ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
-      import loggerf.future.instances.logFuture
+      import loggerf.instances.future.logFuture
       runLog[Future](eab)
     }
 
@@ -348,7 +345,7 @@ object syntaxSpec extends Properties {
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
     ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
-      import loggerf.future.instances.logFuture
+      import loggerf.instances.future.logFuture
       runLog[Future](eab)
     }
 
@@ -388,7 +385,7 @@ object syntaxSpec extends Properties {
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
       ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
-        import loggerf.future.instances.logFuture
+        import loggerf.instances.future.logFuture
         runLog[Future]
       }
 
@@ -433,7 +430,7 @@ object syntaxSpec extends Properties {
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
       ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
-        import loggerf.future.instances.logFuture
+        import loggerf.instances.future.logFuture
         runLog[Future](logMsg)
       }
 
@@ -477,7 +474,7 @@ object syntaxSpec extends Properties {
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
       ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
-        import loggerf.future.instances.logFuture
+        import loggerf.instances.future.logFuture
         runLog[Future](logMsg)
       }
 
@@ -522,7 +519,7 @@ object syntaxSpec extends Properties {
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
       ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
-        import loggerf.future.instances.logFuture
+        import loggerf.instances.future.logFuture
         runLog[Future](logMsg)
       }
 
@@ -569,7 +566,7 @@ object syntaxSpec extends Properties {
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
       ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
-        import loggerf.future.instances.logFuture
+        import loggerf.instances.future.logFuture
         runLog[Future](eab)
       }
 
@@ -616,7 +613,7 @@ object syntaxSpec extends Properties {
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
       ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
-        import loggerf.future.instances.logFuture
+        import loggerf.instances.future.logFuture
         runLog[Future](eab)
       }
 
@@ -663,7 +660,7 @@ object syntaxSpec extends Properties {
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
       ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
-        import loggerf.future.instances.logFuture
+        import loggerf.instances.future.logFuture
         runLog[Future](eab)
       }
 


### PR DESCRIPTION
# Summary
Close #329 - `loggerf.future.instances.logFuture` => `loggerf.instances.future.logFuture`