### PR TITLE
logger-f v2.0.0-beta2

### DIFF
--- a/changelogs/2.0.0-beta2.md
+++ b/changelogs/2.0.0-beta2.md
@@ -1,0 +1,37 @@
+## [2.0.0-beta2](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+created%3A2022-03-07..2022-09-24) - 2022-09-25
+
+## Done
+* Add `ignoreA(A)` syntax (#307)
+  ```scala
+  val fa: F[Option[A]] = ...
+  log(fa)(info("Not found"), ignoreA)
+  fa.log(info("Not found"), ignoreA)
+  // If None, log "Not found"
+  // If Some(value), ignore logging
+  ```
+  ```scala
+  val fab: F[Either[A, B]] = ...
+  log(fab)(ignoreA, b => info(s"It's Right($b)"))
+  fab.log(ignoreA, b => info(s"It's Right($b)"))
+  // If Left, ignore logging
+  // If Right, log
+  ```
+  ```scala
+  val fab: F[Either[A, B]] = ...
+  log(fab)(a => info(s"It's Left($a)"), ignoreA)
+  fab.log(a => info(s"It's Left($a)"), ignoreA)
+  // If Left, log
+  // If Right, ignore logging
+  ```
+* Upgrade `effectie` to `2.0.0-beta2` (#311)
+* Remove `logPure()` (#314)
+  * `logPure()` is unnecessary as `log()` should use `pureOf` internally instead of `effectOf`.
+* Upgrade log libraries (#316)
+  * `SLF4J`: `1.7.30` => `1.7.36`
+  * `Logback`: `1.2.10` => `1.2.11`
+  * `Log4j 2`: `2.17.0` => `2.19.0`
+* Remove `effectie-syntax` from the `logger-f-core` project (#318)
+* Move `loggerf.cats.instances.logF` to `loggerf.instances.cats` (#321)
+* Change `loggerf.cats.syntax` to `loggerf.syntax` (#322)
+* `loggerf.cats.show` => `loggerf.instances.show` (#326)
+* `loggerf.future.instances.logFuture` => `loggerf.instances.future.logFuture` (#329)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.0.0-SNAPSHOT"
+ThisBuild / version := "2.0.0-beta2"


### PR DESCRIPTION
# logger-f v2.0.0-beta2
## [2.0.0-beta2](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+created%3A2022-03-07..2022-09-24) - 2022-09-25

## Done
* Add `ignoreA(A)` syntax (#307)
  ```scala
  val fa: F[Option[A]] = ...
  log(fa)(info("Not found"), ignoreA)
  fa.log(info("Not found"), ignoreA)
  // If None, log "Not found"
  // If Some(value), ignore logging
  ```
  ```scala
  val fab: F[Either[A, B]] = ...
  log(fab)(ignoreA, b => info(s"It's Right($b)"))
  fab.log(ignoreA, b => info(s"It's Right($b)"))
  // If Left, ignore logging
  // If Right, log
  ```
  ```scala
  val fab: F[Either[A, B]] = ...
  log(fab)(a => info(s"It's Left($a)"), ignoreA)
  fab.log(a => info(s"It's Left($a)"), ignoreA)
  // If Left, log
  // If Right, ignore logging
  ```
* Upgrade `effectie` to `2.0.0-beta2` (#311)
* Remove `logPure()` (#314)
  * `logPure()` is unnecessary as `log()` should use `pureOf` internally instead of `effectOf`.
* Upgrade log libraries (#316)
  * `SLF4J`: `1.7.30` => `1.7.36`
  * `Logback`: `1.2.10` => `1.2.11`
  * `Log4j 2`: `2.17.0` => `2.19.0`
* Remove `effectie-syntax` from the `logger-f-core` project (#318)
* Move `loggerf.cats.instances.logF` to `loggerf.instances.cats` (#321)
* Change `loggerf.cats.syntax` to `loggerf.syntax` (#322)
* `loggerf.cats.show` => `loggerf.instances.show` (#326)
* `loggerf.future.instances.logFuture` => `loggerf.instances.future.logFuture` (#329)
