### PR TITLE
Close #335 - Add ToLog.by[A](A => String): ToLog[A]

### DIFF
--- a/modules/logger-f-core/shared/src/main/scala-2/loggerf/core/ToLog.scala
+++ b/modules/logger-f-core/shared/src/main/scala-2/loggerf/core/ToLog.scala
@@ -9,4 +9,6 @@ trait ToLog[A] {
 
 object ToLog {
   def apply[A: ToLog]: ToLog[A] = implicitly[ToLog[A]]
+
+  def by[A](f: A => String): ToLog[A] = f(_)
 }

--- a/modules/logger-f-core/shared/src/main/scala-3/loggerf/core/ToLog.scala
+++ b/modules/logger-f-core/shared/src/main/scala-3/loggerf/core/ToLog.scala
@@ -9,4 +9,6 @@ trait ToLog[A] {
 
 object ToLog {
   def apply[A: ToLog]: ToLog[A] = summon[ToLog[A]]
+
+  def by[A](f: A => String): ToLog[A] = f(_)
 }

--- a/modules/logger-f-core/shared/src/test/scala/loggerf/core/ToLogSpec.scala
+++ b/modules/logger-f-core/shared/src/test/scala/loggerf/core/ToLogSpec.scala
@@ -1,0 +1,29 @@
+package loggerf.core
+
+import hedgehog._
+import hedgehog.runner._
+
+/** @author Kevin Lee
+  * @since 2022-10-28
+  */
+object ToLogSpec extends Properties {
+  override def tests: List[Test] = List(
+    property("test ToLog.by", testBy)
+  )
+
+  def testBy: Property =
+    for {
+      prefix <- Gen.string(Gen.unicode, Range.linear(1, 10)).log("prefix")
+      s      <- Gen.string(Gen.unicode, Range.linear(5, 10)).log("s")
+    } yield {
+      val foo      = Foo(s)
+      val fooToLog = ToLog.by[Foo](foo => prefix + foo.s)
+
+      val expected = prefix + s
+      val actual   = fooToLog.toLogMessage(foo)
+
+      actual ==== expected
+    }
+
+  final case class Foo(s: String)
+}


### PR DESCRIPTION
# Summary
Close #335 - Add `ToLog.by[A](A => String): ToLog[A]`