### PR TITLE
Close #334 - Add ToLog instance for String (ToLog[String])

### DIFF
--- a/modules/logger-f-core/shared/src/main/scala-2/loggerf/core/ToLog.scala
+++ b/modules/logger-f-core/shared/src/main/scala-2/loggerf/core/ToLog.scala
@@ -11,4 +11,6 @@ object ToLog {
   def apply[A: ToLog]: ToLog[A] = implicitly[ToLog[A]]
 
   def by[A](f: A => String): ToLog[A] = f(_)
+
+  implicit val stringToLog: ToLog[String] = identity
 }

--- a/modules/logger-f-core/shared/src/main/scala-3/loggerf/core/ToLog.scala
+++ b/modules/logger-f-core/shared/src/main/scala-3/loggerf/core/ToLog.scala
@@ -11,4 +11,6 @@ object ToLog {
   def apply[A: ToLog]: ToLog[A] = summon[ToLog[A]]
 
   def by[A](f: A => String): ToLog[A] = f(_)
+
+  given stringToLog: ToLog[String] = identity(_)
 }

--- a/modules/logger-f-core/shared/src/test/scala/loggerf/core/ToLogSpec.scala
+++ b/modules/logger-f-core/shared/src/test/scala/loggerf/core/ToLogSpec.scala
@@ -8,7 +8,8 @@ import hedgehog.runner._
   */
 object ToLogSpec extends Properties {
   override def tests: List[Test] = List(
-    property("test ToLog.by", testBy)
+    property("test ToLog.by", testBy),
+    property("test ToLog[String].toLogMessage", testStringToLog),
   )
 
   def testBy: Property =
@@ -22,6 +23,15 @@ object ToLogSpec extends Properties {
       val expected = prefix + s
       val actual   = fooToLog.toLogMessage(foo)
 
+      actual ==== expected
+    }
+
+  def testStringToLog: Property =
+    for {
+      s <- Gen.string(Gen.unicode, Range.linear(5, 10)).log("s")
+    } yield {
+      val expected = s
+      val actual   = ToLog[String].toLogMessage(s)
       actual ==== expected
     }
 


### PR DESCRIPTION
# Summary
Close #334 - Add `ToLog` instance for `String` (`ToLog[String]`)