### PR TITLE
Close #339 - Add ToLog.fromToString[A] to construct an instance of ToLog[A]

### DIFF
--- a/modules/logger-f-core/shared/src/main/scala-2/loggerf/core/ToLog.scala
+++ b/modules/logger-f-core/shared/src/main/scala-2/loggerf/core/ToLog.scala
@@ -12,5 +12,8 @@ object ToLog {
 
   def by[A](f: A => String): ToLog[A] = f(_)
 
+  @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+  def fromToString[A]: ToLog[A] = _.toString
+
   implicit val stringToLog: ToLog[String] = identity
 }

--- a/modules/logger-f-core/shared/src/main/scala-3/loggerf/core/ToLog.scala
+++ b/modules/logger-f-core/shared/src/main/scala-3/loggerf/core/ToLog.scala
@@ -12,5 +12,7 @@ object ToLog {
 
   def by[A](f: A => String): ToLog[A] = f(_)
 
+  def fromToString[A]: ToLog[A] = _.toString
+
   given stringToLog: ToLog[String] = identity(_)
 }

--- a/modules/logger-f-core/shared/src/test/scala/loggerf/core/ToLogSpec.scala
+++ b/modules/logger-f-core/shared/src/test/scala/loggerf/core/ToLogSpec.scala
@@ -8,7 +8,8 @@ import hedgehog.runner._
   */
 object ToLogSpec extends Properties {
   override def tests: List[Test] = List(
-    property("test ToLog.by", testBy),
+    property("test ToLog.by[A](A => String)", testBy),
+    property("test ToLog.fromToString[A]", testFromToString),
     property("test ToLog[String].toLogMessage", testStringToLog),
   )
 
@@ -21,6 +22,20 @@ object ToLogSpec extends Properties {
       val fooToLog = ToLog.by[Foo](foo => prefix + foo.s)
 
       val expected = prefix + s
+      val actual   = fooToLog.toLogMessage(foo)
+
+      actual ==== expected
+    }
+
+  def testFromToString: Property =
+    for {
+      s      <- Gen.string(Gen.unicode, Range.linear(5, 10)).log("s")
+    } yield {
+      val foo      = Foo(s)
+      val fooToLog = ToLog.fromToString[Foo]
+
+      @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+      val expected = foo.toString
       val actual   = fooToLog.toLogMessage(foo)
 
       actual ==== expected


### PR DESCRIPTION
# Summary
Close #339 - Add `ToLog.fromToString[A]` to construct an instance of `ToLog[A]`