### PR TITLE
logger-f v2.0.0-beta3

### DIFF
--- a/changelogs/2.0.0-beta3.md
+++ b/changelogs/2.0.0-beta3.md
@@ -1,0 +1,41 @@
+## [2.0.0-beta3](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2022-09-25..2022-11-17) - 2022-11-17
+
+## New Features
+* Add `ToLog` instance for `String` (`ToLog[String]`) (#334)
+* Add `ToLog.by[A](A => String): ToLog[A]` (#335)
+  ```scala
+  final case class Foo(n: Int)
+
+  val fooToLog = ToLog.by[Foo](n => s"n: ${n.toString}")
+  // ToLog[Foo]
+  fooToLog.toLogMessage(Foo(123))
+  // n: 123
+  ```
+* Add `ToLog.fromToString[A]` to construct an instance of `ToLog[A]` (#339)
+  ```scala
+  final case class Foo(n: Int)
+
+  implicit val fooToLog: ToLog[Foo] = ToLog.fromToString[Foo]
+  
+  ToLog[Foo].toLogMessage(Foo(999))
+  // Foo(999)
+  ```
+* Add `prefix(String): Prefix` and other methods to use it (#337)
+* Add `debugAWith`, `infoAWith`, `warnAWith`, `errorAWith` taking `Prefix` (#342)
+  * Scala 2
+    ```scala
+    def debugAWith[A: ToLog](prefix: Prefix): A => LogMessage with NotIgnorable
+    def infoAWith[A: ToLog](prefix: Prefix): A => LogMessage with NotIgnorable
+    def warnAWith[A: ToLog](prefix: Prefix): A => LogMessage with NotIgnorable
+    def errorAWith[A: ToLog](prefix: Prefix): A => LogMessage with NotIgnorable
+    ```
+  * Scala 3
+    ```scala
+    def debugAWith[A: ToLog](prefix: Prefix): A => LeveledMessage
+    def infoAWith[A: ToLog](prefix: Prefix): A => LeveledMessage
+    def warnAWith[A: ToLog](prefix: Prefix): A => LeveledMessage
+    def errorAWith[A: ToLog](prefix: Prefix): A => LeveledMessage
+    ```
+
+## Internal Housekeeping
+* Bump Effectie to `2.0.0-beta3` (#351)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.0.0-SNAPSHOT"
+ThisBuild / version := "2.0.0-beta3"


### PR DESCRIPTION
# logger-f v2.0.0-beta3
## [2.0.0-beta3](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2022-09-25..2022-11-17) - 2022-11-17

## New Features
* Add `ToLog` instance for `String` (`ToLog[String]`) (#334)
* Add `ToLog.by[A](A => String): ToLog[A]` (#335)
  ```scala
  final case class Foo(n: Int)

  val fooToLog = ToLog.by[Foo](n => s"n: ${n.toString}")
  // ToLog[Foo]
  fooToLog.toLogMessage(Foo(123))
  // n: 123
  ```
* Add `ToLog.fromToString[A]` to construct an instance of `ToLog[A]` (#339)
  ```scala
  final case class Foo(n: Int)

  implicit val fooToLog: ToLog[Foo] = ToLog.fromToString[Foo]
  
  ToLog[Foo].toLogMessage(Foo(999))
  // Foo(999)
  ```
* Add `prefix(String): Prefix` and other methods to use it (#337)
* Add `debugAWith`, `infoAWith`, `warnAWith`, `errorAWith` taking `Prefix` (#342)
  * Scala 2
    ```scala
    def debugAWith[A: ToLog](prefix: Prefix): A => LogMessage with NotIgnorable
    def infoAWith[A: ToLog](prefix: Prefix): A => LogMessage with NotIgnorable
    def warnAWith[A: ToLog](prefix: Prefix): A => LogMessage with NotIgnorable
    def errorAWith[A: ToLog](prefix: Prefix): A => LogMessage with NotIgnorable
    ```
  * Scala 3
    ```scala
    def debugAWith[A: ToLog](prefix: Prefix): A => LeveledMessage
    def infoAWith[A: ToLog](prefix: Prefix): A => LeveledMessage
    def warnAWith[A: ToLog](prefix: Prefix): A => LeveledMessage
    def errorAWith[A: ToLog](prefix: Prefix): A => LeveledMessage
    ```

## Internal Housekeeping
* Bump Effectie to `2.0.0-beta3` (#351)
