### PR TITLE
logger-f v2.0.0-beta4

### DIFF
--- a/changelogs/2.0.0-beta4.md
+++ b/changelogs/2.0.0-beta4.md
@@ -1,0 +1,25 @@
+## [2.0.0-beta4](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2022-11-18..2022-12-25) - 2022-12-25 🎄
+
+## New Features
+* Add `log_` returning `F[Unit]` (#355)
+  ```scala
+  Log[F].log_(pureOf("blah"))(info) // log info blah then returns F[Unit]
+  log_(pureOf("blah"))(info) // log info blah then returns F[Unit]
+  ```
+* Add `logS(String)(String => LogMessage with NotIgnorable): F[String]` (#358)
+  ```scala
+  logS(String)(String => LogMessage with NotIgnorable): F[String]
+  String.logS(String => LogMessage with NotIgnorable): F[String]
+  ```
+* Add `logS_(String)(String => LogMessage with NotIgnorable): F[Unit]` (#359)
+  ```scala
+  logS_(String)(String => LogMessage with NotIgnorable): F[Unit]
+  String.logS_(String => LogMessage with NotIgnorable): F[Unit]
+  ```
+
+
+## Internal Housekeeping
+* Bump Effectie to `2.0.0-beta4` (#362)
+* Bump logging libraries (#363)
+  * Slf4J `1.7.36` => `2.0.6`
+  * Logback `1.2.11` => `1.4.5`

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.0.0-beta3"
+ThisBuild / version := "2.0.0-beta4"


### PR DESCRIPTION
# logger-f v2.0.0-beta4
## [2.0.0-beta4](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2022-11-18..2022-12-25) - 2022-12-25 🎄

## New Features
* Add `log_` returning `F[Unit]` (#355)
  ```scala
  Log[F].log_(pureOf("blah"))(info) // log info blah then returns F[Unit]
  log_(pureOf("blah"))(info) // log info blah then returns F[Unit]
  ```
* Add `logS(String)(String => LogMessage with NotIgnorable): F[String]` (#358)
  ```scala
  logS(String)(String => LogMessage with NotIgnorable): F[String]
  String.logS(String => LogMessage with NotIgnorable): F[String]
  ```
* Add `logS_(String)(String => LogMessage with NotIgnorable): F[Unit]` (#359)
  ```scala
  logS_(String)(String => LogMessage with NotIgnorable): F[Unit]
  String.logS_(String => LogMessage with NotIgnorable): F[Unit]
  ```


## Internal Housekeeping
* Bump Effectie to `2.0.0-beta4` (#362)
* Bump logging libraries (#363)
  * Slf4J `1.7.36` => `2.0.6`
  * Logback `1.2.11` => `1.4.5`
