### PR TITLE
Close #368 - Fix `non-private` `val` in `GetLogger` which is for extension methods for `CanLog`

### DIFF
--- a/modules/logger-f-core/shared/src/main/scala/loggerf/logger/CanLog.scala
+++ b/modules/logger-f-core/shared/src/main/scala/loggerf/logger/CanLog.scala
@@ -13,7 +13,7 @@ trait CanLog {
 }
 
 object CanLog {
-  implicit class GetLogger(val canLog: CanLog) extends AnyVal {
+  implicit class GetLogger(private val canLog: CanLog) extends AnyVal {
     @inline def getLogger(level: Level): (=> String) => Unit = level match {
       case Level.Debug => canLog.debug
       case Level.Info => canLog.info


### PR DESCRIPTION
# Summary
Close #368 - Fix `non-private` `val` in `GetLogger` which is for extension methods for `CanLog`