### PR TITLE
logger-f v2.0.0-beta5

### DIFF
--- a/changelogs/2.0.0-beta5.md
+++ b/changelogs/2.0.0-beta5.md
@@ -1,0 +1,9 @@
+## [2.0.0-beta5](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2022-12-26..2023-01-14) - 2023-01-14
+
+## Bug Fix
+* Fix `non-private` `val` in `GetLogger` which is for extension methods for `CanLog` (#368)
+
+
+## Internal Housekeeping
+* Upgrade `effectie` to `2.0.0-beta5` and `cats` to `2.7.0` (#372)
+* Enable Scalafmt and Scalafix checks (#370)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.0.0-SNAPSHOT"
+ThisBuild / version := "2.0.0-beta5"


### PR DESCRIPTION
# logger-f v2.0.0-beta5
## [2.0.0-beta5](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2022-12-26..2023-01-14) - 2023-01-14

## Bug Fix
* Fix `non-private` `val` in `GetLogger` which is for extension methods for `CanLog` (#368)


## Internal Housekeeping
* Upgrade `effectie` to `2.0.0-beta5` and `cats` to `2.7.0` (#372)
* Enable Scalafmt and Scalafix checks (#370)
