### PR TITLE
logger-f v2.0.0-beta6

### DIFF
--- a/changelogs/2.0.0-beta6.md
+++ b/changelogs/2.0.0-beta6.md
@@ -1,0 +1,4 @@
+## [2.0.0-beta6](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-01-15..2023-01-21) - 2023-01-22
+
+## Bug Fix
+* Fix: Dynamic log level change is not applied for Slf4J logger (#376)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.0.0-SNAPSHOT"
+ThisBuild / version := "2.0.0-beta6"


### PR DESCRIPTION
# logger-f v2.0.0-beta6
## [2.0.0-beta6](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-01-15..2023-01-21) - 2023-01-22

## Bug Fix
* Fix: Dynamic log level change is not applied for Slf4J logger (#376)
