### PR TITLE
Close #379 - Make logS, logS_ and prefix lazy with call-by-name and thunk

### DIFF
--- a/.github/workflows/manual-github-release.yml
+++ b/.github/workflows/manual-github-release.yml
@@ -51,7 +51,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.RELEASE_AUTH_TOKEN_GITHUB }}
         run: |
           echo "Run] sbt GitHub release"
-          echo 'sbt -J-Xmx2048m devOopsGitHubRelease'
+          echo 'sbt -J-Xmx4G devOopsGitHubRelease'
           sbt \
-            -J-Xmx2048m \
+            -J-Xmx4G \
             devOopsGitHubRelease

--- a/.github/workflows/manual-github-upload-artifacts-and-publish.yml
+++ b/.github/workflows/manual-github-upload-artifacts-and-publish.yml
@@ -59,9 +59,9 @@ jobs:
           mkdir -p dotty-docs
           export SOURCE_DATE_EPOCH=$(date +%s)
           echo "SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH"
-          echo 'sbt -J-Xmx2048m ++${{ matrix.scala.version }}! -v clean test packagedArtifacts devOopsGitHubReleaseUploadArtifacts publish'
+          echo 'sbt -J-Xmx4G ++${{ matrix.scala.version }}! -v clean test packagedArtifacts devOopsGitHubReleaseUploadArtifacts publish'
           sbt \
-            -J-Xmx2048m \
+            -J-Xmx4G \
             ++${{ matrix.scala.version }}! \
             -v \
             clean \

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -58,9 +58,9 @@ jobs:
           mkdir -p dotty-docs
           export SOURCE_DATE_EPOCH=$(date +%s)
           echo "SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH"
-          echo 'sbt -J-Xmx2048m ++${{ matrix.scala.version }}! -v clean test packagedArtifacts devOopsGitHubReleaseUploadArtifacts publish'
+          echo 'sbt -J-Xmx4G ++${{ matrix.scala.version }}! -v clean test packagedArtifacts devOopsGitHubReleaseUploadArtifacts publish'
           sbt \
-            -J-Xmx2048m \
+            -J-Xmx4G \
             ++${{ matrix.scala.version }}! \
             -v \
             clean \

--- a/.github/workflows/sbt-build-all.sh
+++ b/.github/workflows/sbt-build-all.sh
@@ -28,9 +28,9 @@ else
 #    echo "report build but it does nothing for now."
   fi
 
-#  echo "sbt -J-Xmx2048m ++${scala_version}! -v clean ${test_task}"
+#  echo "sbt -J-Xmx4G ++${scala_version}! -v clean ${test_task}"
 #  sbt \
-#    -J-Xmx2048m \
+#    -J-Xmx4G \
 #    ++${scala_version}! \
 #    -v \
 #    clean \
@@ -42,7 +42,7 @@ else
   if [[ "$CURRENT_BRANCH_NAME" == "main" || "$CURRENT_BRANCH_NAME" == "logger-f-1" || "$CURRENT_BRANCH_NAME" == "release" ]]
   then
     sbt \
-      -J-Xmx2048m \
+      -J-Xmx4G \
       ++${scala_version}! \
       -v \
       clean \
@@ -50,7 +50,7 @@ else
       packagedArtifacts
   else
     sbt \
-      -J-Xmx2048m \
+      -J-Xmx4G \
       ++${scala_version}! \
       -v \
       clean \

--- a/.github/workflows/sbt-build.sh
+++ b/.github/workflows/sbt-build.sh
@@ -21,12 +21,12 @@ else
 
   if [[ "$CURRENT_BRANCH_NAME" == "main" || "$CURRENT_BRANCH_NAME" == "logger-f-1" || "$CURRENT_BRANCH_NAME" == "release" ]]
   then
-#    sbt -J-Xmx2048m "project ${project_name}" ++${scala_version}! -v clean coverage test coverageReport coverageAggregate
-#    sbt -J-Xmx2048m "project ${project_name}" ++${scala_version}! -v coveralls
-#    sbt -J-Xmx2048m "project ${project_name}" ++${scala_version}! -v clean packagedArtifacts
+#    sbt -J-Xmx4G "project ${project_name}" ++${scala_version}! -v clean coverage test coverageReport coverageAggregate
+#    sbt -J-Xmx4G "project ${project_name}" ++${scala_version}! -v coveralls
+#    sbt -J-Xmx4G "project ${project_name}" ++${scala_version}! -v clean packagedArtifacts
     mkdir -p dotty-docs
     sbt \
-      -J-Xmx2048m \
+      -J-Xmx4G \
       "project ${project_name}" \
       ++${scala_version}! \
       -v \
@@ -34,10 +34,10 @@ else
       test \
       packagedArtifacts
   else
-#    sbt -J-Xmx2048m "project ${project_name}" ++${scala_version}! -v clean coverage test coverageReport coverageAggregate package
-#    sbt -J-Xmx2048m "project ${project_name}" ++${scala_version}! -v coveralls
+#    sbt -J-Xmx4G "project ${project_name}" ++${scala_version}! -v clean coverage test coverageReport coverageAggregate package
+#    sbt -J-Xmx4G "project ${project_name}" ++${scala_version}! -v coveralls
     sbt \
-      -J-Xmx2048m \
+      -J-Xmx4G \
       "project ${project_name}" \
       ++${scala_version}! \
       -v \

--- a/build.sbt
+++ b/build.sbt
@@ -213,7 +213,7 @@ lazy val sbtLogging    =
             libs.sbtLoggingLib % "1.3.3"
           ).map(_ % Provided)
 
-        case (SemVer.Major(2), SemVer.Minor(13), _) | (SemVer.Major(3), SemVer.Minor(0), _) =>
+        case (SemVer.Major(2), SemVer.Minor(13), _) | (SemVer.Major(3), SemVer.Minor(_), _) =>
           List(
             libs.sbtLoggingLib % "1.5.8"
           ).map(_ % Provided).map(_.cross(CrossVersion.for3Use2_13))

--- a/modules/logger-f-core/shared/src/main/scala-2/loggerf/LogMessage.scala
+++ b/modules/logger-f-core/shared/src/main/scala-2/loggerf/LogMessage.scala
@@ -10,6 +10,25 @@ object LogMessage {
   sealed trait Ignorable extends MaybeIgnorable
   sealed trait NotIgnorable extends MaybeIgnorable
 
-  final case class LeveledMessage(message: String, level: Level) extends LogMessage with NotIgnorable
+  final case class LeveledMessage(message: () => String, level: Level) extends LogMessage with NotIgnorable
+  object LeveledMessage {
+
+    trait Leveled {
+      def level: Level
+
+      def toLazyInput(message: => String): LeveledMessage
+    }
+
+    final class StringToLeveledMessage(override val level: Level) extends (String => LeveledMessage) with Leveled {
+      override def apply(message: String): LeveledMessage = LeveledMessage(() => message, level)
+
+      override def toLazyInput(message: => String): LeveledMessage = LeveledMessage(() => message, level)
+    }
+
+    object StringToLeveledMessage {
+      def apply(level: Level): (String => LeveledMessage) with Leveled = new StringToLeveledMessage(level)
+    }
+
+  }
   case object Ignore extends LogMessage with Ignorable
 }

--- a/modules/logger-f-core/shared/src/main/scala-2/loggerf/core/syntax/ExtraSyntax.scala
+++ b/modules/logger-f-core/shared/src/main/scala-2/loggerf/core/syntax/ExtraSyntax.scala
@@ -9,20 +9,20 @@ trait ExtraSyntax {
   import loggerf.core.syntax.ExtraSyntax._
   import loggerf.{Level, LogMessage}
 
-  def prefix(pre: String): Prefix =
+  def prefix(pre: => String): Prefix =
     new Prefix(message => pre + message)
 
   @inline private[ExtraSyntax] def debug0(f: String => String): String => LogMessage with NotIgnorable =
-    message => LeveledMessage(f(message), Level.debug)
+    message => LeveledMessage(() => f(message), Level.debug)
 
   @inline private[ExtraSyntax] def info0(f: String => String): String => LogMessage with NotIgnorable =
-    message => LeveledMessage(f(message), Level.info)
+    message => LeveledMessage(() => f(message), Level.info)
 
   @inline private[ExtraSyntax] def warn0(f: String => String): String => LogMessage with NotIgnorable =
-    message => LeveledMessage(f(message), Level.warn)
+    message => LeveledMessage(() => f(message), Level.warn)
 
   @inline private[ExtraSyntax] def error0(f: String => String): String => LogMessage with NotIgnorable =
-    message => LeveledMessage(f(message), Level.error)
+    message => LeveledMessage(() => f(message), Level.error)
 
   def debug(prefix: Prefix): String => LogMessage with NotIgnorable =
     debug0(prefix.value)

--- a/modules/logger-f-core/shared/src/main/scala-2/loggerf/core/syntax/LogMessageSyntax.scala
+++ b/modules/logger-f-core/shared/src/main/scala-2/loggerf/core/syntax/LogMessageSyntax.scala
@@ -7,29 +7,29 @@ trait LogMessageSyntax {
   import loggerf.LogMessage._
   import loggerf.{Level, LogMessage}
 
-  def debug(message: String): LogMessage with NotIgnorable =
-    LeveledMessage(message, Level.debug)
+  val debug: (String => LogMessage with NotIgnorable) with LeveledMessage.Leveled =
+    LeveledMessage.StringToLeveledMessage(Level.debug)
 
-  def info(message: String): LogMessage with NotIgnorable =
-    LeveledMessage(message, Level.info)
+  val info: (String => LogMessage with NotIgnorable) with LeveledMessage.Leveled =
+    LeveledMessage.StringToLeveledMessage(Level.info)
 
-  def warn(message: String): LogMessage with NotIgnorable =
-    LeveledMessage(message, Level.warn)
+  val warn: (String => LogMessage with NotIgnorable) with LeveledMessage.Leveled =
+    LeveledMessage.StringToLeveledMessage(Level.warn)
 
-  def error(message: String): LogMessage with NotIgnorable =
-    LeveledMessage(message, Level.error)
+  val error: (String => LogMessage with NotIgnorable) with LeveledMessage.Leveled =
+    LeveledMessage.StringToLeveledMessage(Level.error)
 
   def debugA[A: ToLog](a: A): LogMessage with NotIgnorable =
-    LeveledMessage(ToLog[A].toLogMessage(a), Level.debug)
+    LeveledMessage(() => ToLog[A].toLogMessage(a), Level.debug)
 
   def infoA[A: ToLog](a: A): LogMessage with NotIgnorable =
-    LeveledMessage(ToLog[A].toLogMessage(a), Level.info)
+    LeveledMessage(() => ToLog[A].toLogMessage(a), Level.info)
 
   def warnA[A: ToLog](a: A): LogMessage with NotIgnorable =
-    LeveledMessage(ToLog[A].toLogMessage(a), Level.warn)
+    LeveledMessage(() => ToLog[A].toLogMessage(a), Level.warn)
 
   def errorA[A: ToLog](a: A): LogMessage with NotIgnorable =
-    LeveledMessage(ToLog[A].toLogMessage(a), Level.error)
+    LeveledMessage(() => ToLog[A].toLogMessage(a), Level.error)
 
   def ignore: LogMessage with Ignorable = Ignore
 

--- a/modules/logger-f-core/shared/src/main/scala-2/loggerf/core/syntax/LogSyntax.scala
+++ b/modules/logger-f-core/shared/src/main/scala-2/loggerf/core/syntax/LogSyntax.scala
@@ -22,12 +22,16 @@ trait LogSyntax {
   ): F[Unit] =
     L.log_(fa)(toLeveledMessage)
 
-  @inline def logS[F[*]](message: String)(toLeveledMessage: String => LogMessage with NotIgnorable)(
+  @inline def logS[F[*]](message: => String)(
+    toLeveledMessage: (String => LogMessage with NotIgnorable) with LogMessage.LeveledMessage.Leveled
+  )(
     implicit L: Log[F]
   ): F[String] =
     L.logS(message)(toLeveledMessage)
 
-  @inline def logS_[F[*]](message: String)(toLeveledMessage: String => LogMessage with NotIgnorable)(
+  @inline def logS_[F[*]](message: => String)(
+    toLeveledMessage: (String => LogMessage with NotIgnorable) with LogMessage.LeveledMessage.Leveled
+  )(
     implicit L: Log[F]
   ): F[Unit] =
     L.logS_(message)(toLeveledMessage)
@@ -76,7 +80,7 @@ trait LogSyntax {
   implicit def logFOfASyntax[F[*], A](fa: F[A]): LogFOfASyntax[F, A] = new LogFOfASyntax[F, A](fa)
 
   @SuppressWarnings(Array("org.wartremover.warts.ImplicitConversion"))
-  implicit def logFStringSyntax(message: String): LogFForStringSyntax = new LogFForStringSyntax(message)
+  implicit def logFStringSyntax(message: => String): LogFForStringSyntax = new LogFForStringSyntax(() => message)
 
   @SuppressWarnings(Array("org.wartremover.warts.ImplicitConversion"))
   implicit def logFOfOptionSyntax[F[*], A](foa: F[Option[A]]): LogFOfOptionSyntax[F, A] =
@@ -96,12 +100,20 @@ object LogSyntax extends LogSyntax {
       LogSyntax.log_(fa)(toLeveledMessage)
   }
 
-  final class LogFForStringSyntax(private val message: String) extends AnyVal {
-    @inline def logS[F[*]](toLeveledMessage: String => LogMessage with NotIgnorable)(implicit L: Log[F]): F[String] =
-      LogSyntax.logS(message)(toLeveledMessage)
+  final class LogFForStringSyntax(private val message: () => String) extends AnyVal {
+    @inline def logS[F[*]](
+      toLeveledMessage: (String => LogMessage with NotIgnorable) with LogMessage.LeveledMessage.Leveled
+    )(
+      implicit L: Log[F]
+    ): F[String] =
+      LogSyntax.logS(message())(toLeveledMessage)
 
-    @inline def logS_[F[*]](toLeveledMessage: String => LogMessage with NotIgnorable)(implicit L: Log[F]): F[Unit] =
-      LogSyntax.logS_(message)(toLeveledMessage)
+    @inline def logS_[F[*]](
+      toLeveledMessage: (String => LogMessage with NotIgnorable) with LogMessage.LeveledMessage.Leveled
+    )(
+      implicit L: Log[F]
+    ): F[Unit] =
+      LogSyntax.logS_(message())(toLeveledMessage)
   }
 
   final class LogFOfOptionSyntax[F[*], A](private val foa: F[Option[A]]) extends AnyVal {

--- a/modules/logger-f-core/shared/src/main/scala-3/loggerf/LeveledMessage.scala
+++ b/modules/logger-f-core/shared/src/main/scala-3/loggerf/LeveledMessage.scala
@@ -3,5 +3,23 @@ package loggerf
 /** @author Kevin Lee
   * @since 2020-04-10
   */
-final case class LeveledMessage(message: String, level: Level)
+final case class LeveledMessage(message: () => String, level: Level)
+object LeveledMessage {
+
+  trait Leveled {
+    def level: Level
+
+    def toLazyInput(message: => String): LeveledMessage
+  }
+
+  final class StringToLeveledMessage(override val level: Level) extends (String => LeveledMessage) with Leveled {
+    override def apply(message: String): LeveledMessage = LeveledMessage(() => message, level)
+
+    override def toLazyInput(message: => String): LeveledMessage = LeveledMessage(() => message, level)
+  }
+  object StringToLeveledMessage {
+    def apply(level: Level): (String => LeveledMessage) with Leveled = new StringToLeveledMessage(level)
+  }
+
+}
 case object Ignore

--- a/modules/logger-f-core/shared/src/main/scala-3/loggerf/core/ToLog.scala
+++ b/modules/logger-f-core/shared/src/main/scala-3/loggerf/core/ToLog.scala
@@ -12,6 +12,7 @@ object ToLog {
 
   def by[A](f: A => String): ToLog[A] = f(_)
 
+  @SuppressWarnings(Array("org.wartremover.warts.ToString"))
   def fromToString[A]: ToLog[A] = _.toString
 
   inline given stringToLog: ToLog[String] = identity(_)

--- a/modules/logger-f-core/shared/src/main/scala-3/loggerf/core/syntax/ExtraSyntax.scala
+++ b/modules/logger-f-core/shared/src/main/scala-3/loggerf/core/syntax/ExtraSyntax.scala
@@ -7,23 +7,22 @@ import loggerf.core.syntax.ExtraSyntax.Prefix
   */
 trait ExtraSyntax {
 
-  import loggerf.LeveledMessage._
   import loggerf.{Level, LeveledMessage}
 
-  def prefix(pre: String): Prefix =
+  def prefix(pre: => String): Prefix =
     Prefix(message => pre + message)
 
   inline private def debug0(f: String => String): String => LeveledMessage =
-    message => LeveledMessage(f(message), Level.debug)
+    message => LeveledMessage(() => f(message), Level.debug)
 
   inline private def info0(f: String => String): String => LeveledMessage =
-    message => LeveledMessage(f(message), Level.info)
+    message => LeveledMessage(() => f(message), Level.info)
 
   inline private def warn0(f: String => String): String => LeveledMessage =
-    message => LeveledMessage(f(message), Level.warn)
+    message => LeveledMessage(() => f(message), Level.warn)
 
   inline private def error0(f: String => String): String => LeveledMessage =
-    message => LeveledMessage(f(message), Level.error)
+    message => LeveledMessage(() => f(message), Level.error)
 
   def debug(prefix: Prefix): String => LeveledMessage =
     debug0(prefix.value)

--- a/modules/logger-f-core/shared/src/main/scala-3/loggerf/core/syntax/LogMessageSyntax.scala
+++ b/modules/logger-f-core/shared/src/main/scala-3/loggerf/core/syntax/LogMessageSyntax.scala
@@ -7,33 +7,33 @@ import loggerf.Level
 
 trait LogMessageSyntax {
 
-  def debug(message: String): LeveledMessage =
-    LeveledMessage(message, Level.debug)
+  val debug: (String => LeveledMessage) with LeveledMessage.Leveled =
+    LeveledMessage.StringToLeveledMessage(Level.debug)
 
-  def info(message: String): LeveledMessage =
-    LeveledMessage(message, Level.info)
+  val info: (String => LeveledMessage) with LeveledMessage.Leveled =
+    LeveledMessage.StringToLeveledMessage(Level.info)
 
-  def warn(message: String): LeveledMessage =
-    LeveledMessage(message, Level.warn)
+  val warn: (String => LeveledMessage) with LeveledMessage.Leveled =
+    LeveledMessage.StringToLeveledMessage(Level.warn)
 
-  def error(message: String): LeveledMessage =
-    LeveledMessage(message, Level.error)
+  val error: (String => LeveledMessage) with LeveledMessage.Leveled =
+    LeveledMessage.StringToLeveledMessage(Level.error)
 
   def debugA[A: ToLog](a: A): LeveledMessage =
-    LeveledMessage(ToLog[A].toLogMessage(a), Level.debug)
+    LeveledMessage(() => ToLog[A].toLogMessage(a), Level.debug)
 
   def infoA[A: ToLog](a: A): LeveledMessage =
-    LeveledMessage(ToLog[A].toLogMessage(a), Level.info)
+    LeveledMessage(() => ToLog[A].toLogMessage(a), Level.info)
 
   def warnA[A: ToLog](a: A): LeveledMessage =
-    LeveledMessage(ToLog[A].toLogMessage(a), Level.warn)
+    LeveledMessage(() => ToLog[A].toLogMessage(a), Level.warn)
 
   def errorA[A: ToLog](a: A): LeveledMessage =
-    LeveledMessage(ToLog[A].toLogMessage(a), Level.error)
+    LeveledMessage(() => ToLog[A].toLogMessage(a), Level.error)
 
   def ignore: Ignore.type = Ignore
 
-  def ignoreA[A](a: A): Ignore.type = ignore
+  def ignoreA[A](a: => A): Ignore.type = ignore
 
 }
 

--- a/modules/logger-f-core/shared/src/main/scala-3/loggerf/core/syntax/LogSyntax.scala
+++ b/modules/logger-f-core/shared/src/main/scala-3/loggerf/core/syntax/LogSyntax.scala
@@ -20,11 +20,15 @@ trait LogSyntax {
       L.log_(fa)(toLeveledMessage)
   }
 
-  extension (message: String) {
-    def logS[F[*]](toLeveledMessage: String => LeveledMessage)(using L: Log[F]): F[String] =
+  extension (message: => String) {
+    def logS[F[*]](toLeveledMessage: (String => LeveledMessage) with LeveledMessage.Leveled)(
+      using L: Log[F]
+    ): F[String] =
       L.logS(message)(toLeveledMessage)
 
-    def logS_[F[*]](toLeveledMessage: String => LeveledMessage)(using L: Log[F]): F[Unit] =
+    def logS_[F[*]](toLeveledMessage: (String => LeveledMessage) with LeveledMessage.Leveled)(
+      using L: Log[F]
+    ): F[Unit] =
       L.logS_(message)(toLeveledMessage)
   }
 

--- a/modules/logger-f-core/shared/src/test/scala-2/loggerf/test_data/Something.scala
+++ b/modules/logger-f-core/shared/src/test/scala-2/loggerf/test_data/Something.scala
@@ -1,0 +1,8 @@
+package loggerf.test_data
+
+import loggerf.core.ToLog
+
+final case class Something(message: String)
+object Something {
+  implicit val somethingToLog: ToLog[Something] = something => s"Something(message=${something.message})"
+}

--- a/modules/logger-f-core/shared/src/test/scala-3/loggerf/test_data/Something.scala
+++ b/modules/logger-f-core/shared/src/test/scala-3/loggerf/test_data/Something.scala
@@ -1,0 +1,8 @@
+package loggerf.test_data
+
+import loggerf.core.ToLog
+
+final case class Something(message: String)
+object Something {
+  given somethingToLog: ToLog[Something] = something => s"Something(message=${something.message})"
+}

--- a/modules/logger-f-core/shared/src/test/scala/loggerf/syntax/LeveledMessageSyntaxSpec.scala
+++ b/modules/logger-f-core/shared/src/test/scala/loggerf/syntax/LeveledMessageSyntaxSpec.scala
@@ -8,6 +8,7 @@ import hedgehog.runner._
 import loggerf.core._
 import loggerf.core.syntax.all._
 import loggerf.logger.LoggerForTesting
+import loggerf.test_data.Something
 
 /** @author Kevin Lee
   * @since 2022-02-19
@@ -46,11 +47,6 @@ object LeveledMessageSyntaxSpec extends Properties {
 
     runLog[Identity]
     logger ==== expected
-  }
-
-  final case class Something(message: String)
-  object Something {
-    implicit val somethingToLog: ToLog[Something] = something => s"Something(message=${something.message})"
   }
 
   def testLeveledLogMessageWithToLog: Property = for {

--- a/project/ProjectInfo.scala
+++ b/project/ProjectInfo.scala
@@ -8,7 +8,7 @@ object ProjectInfo {
     case "2.10" =>
       Seq.empty
     case _ =>
-      Warts.allBut(Wart.DefaultArguments, Wart.Overloading, Wart.Any, Wart.Nothing, Wart.NonUnitStatements)
+      Warts.allBut(Wart.DefaultArguments, Wart.Overloading, Wart.Any, Wart.Nothing, Wart.NonUnitStatements, Wart.ImplicitParameter)
   }
 
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.0
+sbt.version=1.8.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,6 +4,7 @@ addDependencyTreePlugin
 
 addSbtPlugin("com.github.sbt"  % "sbt-ci-release"  % "1.5.10")
 addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.15")
+//addSbtPlugin("org.wartremover" % "sbt-wartremover" % "3.0.5")
 addSbtPlugin("ch.epfl.scala"   % "sbt-scalafix"    % "0.10.4")
 addSbtPlugin("org.scalameta"   % "sbt-scalafmt"    % "2.4.6")
 addSbtPlugin("org.scoverage"   % "sbt-scoverage"   % "2.0.6")


### PR DESCRIPTION
# Summary
Close #379 - Make `logS`, `logS_` and `prefix` lazy with call-by-name and thunk