### PR TITLE
logger-f v2.0.0-beta7

### DIFF
--- a/changelogs/2.0.0-beta7.md
+++ b/changelogs/2.0.0-beta7.md
@@ -1,0 +1,7 @@
+## [2.0.0-beta7](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-01-22..2023-02-07) - 2023-02-07
+
+## New Feature
+* Add `logger-f-test-kit` with `CanLog` instance for testing (#388)
+
+## Improvement
+* Make `logS`, `logS_` and `prefix` lazy with call-by-name and thunk (#379)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.0.0-SNAPSHOT"
+ThisBuild / version := "2.0.0-beta7"


### PR DESCRIPTION
# logger-f v2.0.0-beta7
## [2.0.0-beta7](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-01-22..2023-02-07) - 2023-02-07

## New Feature
* Add `logger-f-test-kit` with `CanLog` instance for testing (#388)

## Improvement
* Make `logS`, `logS_` and `prefix` lazy with call-by-name and thunk (#379)
