### PR TITLE
Fix #395 - `debug(Prefix)`, `info(Prefix)`, `warn(Prefix)` and `error(Prefix)` do not work with `logS` and `logS_`

### DIFF
--- a/modules/logger-f-core/shared/src/main/scala-2/loggerf/LogMessage.scala
+++ b/modules/logger-f-core/shared/src/main/scala-2/loggerf/LogMessage.scala
@@ -29,6 +29,19 @@ object LogMessage {
       def apply(level: Level): (String => LeveledMessage) with Leveled = new StringToLeveledMessage(level)
     }
 
+    final class PreprocessedStringToLeveledMessage(override val level: Level, preprocess: String => String)
+        extends (String => LeveledMessage)
+        with Leveled {
+      override def apply(message: String): LeveledMessage = LeveledMessage(() => preprocess(message), level)
+
+      override def toLazyInput(message: => String): LeveledMessage = LeveledMessage(() => preprocess(message), level)
+    }
+
+    object PreprocessedStringToLeveledMessage {
+      def apply(level: Level, preprocess: String => String): (String => LeveledMessage) with Leveled =
+        new PreprocessedStringToLeveledMessage(level, preprocess)
+    }
+
   }
   case object Ignore extends LogMessage with Ignorable
 }

--- a/modules/logger-f-core/shared/src/main/scala-2/loggerf/core/syntax/ExtraSyntax.scala
+++ b/modules/logger-f-core/shared/src/main/scala-2/loggerf/core/syntax/ExtraSyntax.scala
@@ -1,5 +1,7 @@
 package loggerf.core.syntax
 
+import loggerf.LogMessage.LeveledMessage.PreprocessedStringToLeveledMessage
+
 /** @author Kevin Lee
   * @since 2022-10-29
   */
@@ -12,28 +14,36 @@ trait ExtraSyntax {
   def prefix(pre: => String): Prefix =
     new Prefix(message => pre + message)
 
-  @inline private[ExtraSyntax] def debug0(f: String => String): String => LogMessage with NotIgnorable =
-    message => LeveledMessage(() => f(message), Level.debug)
+  @inline private[ExtraSyntax] def debug0(
+    f: String => String
+  ): (String => LogMessage with NotIgnorable) with LeveledMessage.Leveled =
+    PreprocessedStringToLeveledMessage(Level.debug, f)
 
-  @inline private[ExtraSyntax] def info0(f: String => String): String => LogMessage with NotIgnorable =
-    message => LeveledMessage(() => f(message), Level.info)
+  @inline private[ExtraSyntax] def info0(
+    f: String => String
+  ): (String => LogMessage with NotIgnorable) with LeveledMessage.Leveled =
+    PreprocessedStringToLeveledMessage(Level.info, f)
 
-  @inline private[ExtraSyntax] def warn0(f: String => String): String => LogMessage with NotIgnorable =
-    message => LeveledMessage(() => f(message), Level.warn)
+  @inline private[ExtraSyntax] def warn0(
+    f: String => String
+  ): (String => LogMessage with NotIgnorable) with LeveledMessage.Leveled =
+    PreprocessedStringToLeveledMessage(Level.warn, f)
 
-  @inline private[ExtraSyntax] def error0(f: String => String): String => LogMessage with NotIgnorable =
-    message => LeveledMessage(() => f(message), Level.error)
+  @inline private[ExtraSyntax] def error0(
+    f: String => String
+  ): (String => LogMessage with NotIgnorable) with LeveledMessage.Leveled =
+    PreprocessedStringToLeveledMessage(Level.error, f)
 
-  def debug(prefix: Prefix): String => LogMessage with NotIgnorable =
+  def debug(prefix: Prefix): (String => LogMessage with NotIgnorable) with LeveledMessage.Leveled =
     debug0(prefix.value)
 
-  def info(prefix: Prefix): String => LogMessage with NotIgnorable =
+  def info(prefix: Prefix): (String => LogMessage with NotIgnorable) with LeveledMessage.Leveled =
     info0(prefix.value)
 
-  def warn(prefix: Prefix): String => LogMessage with NotIgnorable =
+  def warn(prefix: Prefix): (String => LogMessage with NotIgnorable) with LeveledMessage.Leveled =
     warn0(prefix.value)
 
-  def error(prefix: Prefix): String => LogMessage with NotIgnorable =
+  def error(prefix: Prefix): (String => LogMessage with NotIgnorable) with LeveledMessage.Leveled =
     error0(prefix.value)
 
   import loggerf.core.ToLog

--- a/modules/logger-f-core/shared/src/main/scala-3/loggerf/LeveledMessage.scala
+++ b/modules/logger-f-core/shared/src/main/scala-3/loggerf/LeveledMessage.scala
@@ -21,5 +21,17 @@ object LeveledMessage {
     def apply(level: Level): (String => LeveledMessage) with Leveled = new StringToLeveledMessage(level)
   }
 
+  final class PreprocessedStringToLeveledMessage(override val level: Level, preprocess: String => String)
+      extends (String => LeveledMessage)
+      with Leveled {
+    override def apply(message: String): LeveledMessage = LeveledMessage(() => preprocess(message), level)
+
+    override def toLazyInput(message: => String): LeveledMessage = LeveledMessage(() => preprocess(message), level)
+  }
+
+  object PreprocessedStringToLeveledMessage {
+    def apply(level: Level, preprocess: String => String): (String => LeveledMessage) with Leveled =
+      new PreprocessedStringToLeveledMessage(level, preprocess)
+  }
 }
 case object Ignore

--- a/modules/logger-f-core/shared/src/main/scala-3/loggerf/core/syntax/ExtraSyntax.scala
+++ b/modules/logger-f-core/shared/src/main/scala-3/loggerf/core/syntax/ExtraSyntax.scala
@@ -1,6 +1,7 @@
 package loggerf.core.syntax
 
 import loggerf.core.syntax.ExtraSyntax.Prefix
+import loggerf.LeveledMessage.PreprocessedStringToLeveledMessage
 
 /** @author Kevin Lee
   * @since 2022-10-29
@@ -12,28 +13,28 @@ trait ExtraSyntax {
   def prefix(pre: => String): Prefix =
     Prefix(message => pre + message)
 
-  inline private def debug0(f: String => String): String => LeveledMessage =
-    message => LeveledMessage(() => f(message), Level.debug)
+  inline private def debug0(f: String => String): (String => LeveledMessage) with LeveledMessage.Leveled =
+    PreprocessedStringToLeveledMessage(Level.debug, f)
 
-  inline private def info0(f: String => String): String => LeveledMessage =
-    message => LeveledMessage(() => f(message), Level.info)
+  inline private def info0(f: String => String): (String => LeveledMessage) with LeveledMessage.Leveled =
+    PreprocessedStringToLeveledMessage(Level.info, f)
 
-  inline private def warn0(f: String => String): String => LeveledMessage =
-    message => LeveledMessage(() => f(message), Level.warn)
+  inline private def warn0(f: String => String): (String => LeveledMessage) with LeveledMessage.Leveled =
+    PreprocessedStringToLeveledMessage(Level.warn, f)
 
-  inline private def error0(f: String => String): String => LeveledMessage =
-    message => LeveledMessage(() => f(message), Level.error)
+  inline private def error0(f: String => String): (String => LeveledMessage) with LeveledMessage.Leveled =
+    PreprocessedStringToLeveledMessage(Level.error, f)
 
-  def debug(prefix: Prefix): String => LeveledMessage =
+  def debug(prefix: Prefix): (String => LeveledMessage) with LeveledMessage.Leveled =
     debug0(prefix.value)
 
-  def info(prefix: Prefix): String => LeveledMessage =
+  def info(prefix: Prefix): (String => LeveledMessage) with LeveledMessage.Leveled =
     info0(prefix.value)
 
-  def warn(prefix: Prefix): String => LeveledMessage =
+  def warn(prefix: Prefix): (String => LeveledMessage) with LeveledMessage.Leveled =
     warn0(prefix.value)
 
-  def error(prefix: Prefix): String => LeveledMessage =
+  def error(prefix: Prefix): (String => LeveledMessage) with LeveledMessage.Leveled =
     error0(prefix.value)
 
   import loggerf.core.ToLog


### PR DESCRIPTION
# Summary
Fix #395 - `debug(Prefix)`, `info(Prefix)`, `warn(Prefix)` and `error(Prefix)` do not work with `logS` and `logS_`