### PR TITLE
logger-f v2.0.0-beta8

### DIFF
--- a/changelogs/2.0.0-beta8.md
+++ b/changelogs/2.0.0-beta8.md
@@ -1,0 +1,4 @@
+## [2.0.0-beta8](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-02-07..2023-02-07) - 2023-02-07
+
+## Bug Fix
+* `debug(Prefix)`, `info(Prefix)`, `warn(Prefix)` and `error(Prefix)` do not work with `logS` and `logS_` (#395)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.0.0-SNAPSHOT"
+ThisBuild / version := "2.0.0-beta8"


### PR DESCRIPTION
# logger-f v2.0.0-beta8
## [2.0.0-beta8](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-02-07..2023-02-07) - 2023-02-07

## Bug Fix
* `debug(Prefix)`, `info(Prefix)`, `warn(Prefix)` and `error(Prefix)` do not work with `logS` and `logS_` (#395)
