### PR TITLE
logger-f v2.0.0-beta10

### DIFF
--- a/changelogs/2.0.0-beta10.md
+++ b/changelogs/2.0.0-beta10.md
@@ -1,0 +1,10 @@
+## [2.0.0-beta10](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-02-13..2023-02-26) - 2023-02-26
+
+## Update
+* Add missing `implicit` instance messages (#410)
+
+## Internal Housekeeping
+* Upgrade `effectie` to `2.0.0-beta7` (#413)
+* Bump and clean up libraries (#415)
+  * Bump: `hedgehog-extra` to `0.3.0`
+  * Remove `extras-cats` from `logger-f-cats` and `logger-f-test-kit` as it's not used by them

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.0.0-SNAPSHOT"
+ThisBuild / version := "2.0.0-beta10"


### PR DESCRIPTION
# logger-f v2.0.0-beta10
## [2.0.0-beta10](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-02-13..2023-02-26) - 2023-02-26

## Update
* Add missing `implicit` instance messages (#410)

## Internal Housekeeping
* Upgrade `effectie` to `2.0.0-beta7` (#413)
* Bump and clean up libraries (#415)
  * Bump: `hedgehog-extra` to `0.3.0`
  * Remove `extras-cats` from `logger-f-cats` and `logger-f-test-kit` as it's not used by them
