### PR TITLE
logger-f v2.0.0-beta11

### DIFF
--- a/changelogs/2.0.0-beta11.md
+++ b/changelogs/2.0.0-beta11.md
@@ -1,0 +1,4 @@
+## [2.0.0-beta11](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-02-27..2023-03-08) - 2023-03-08
+
+## Internal Housekeeping
+* Upgrade `effectie` to `2.0.0-beta8` (#420)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.0.0-SNAPSHOT"
+ThisBuild / version := "2.0.0-beta11"


### PR DESCRIPTION
# logger-f v2.0.0-beta11
## [2.0.0-beta11](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-02-27..2023-03-08) - 2023-03-08

## Internal Housekeeping
* Upgrade `effectie` to `2.0.0-beta8` (#420)
