### PR TITLE
logger-f v2.0.0-beta13

### DIFF
--- a/changelogs/2.0.0-beta13.md
+++ b/changelogs/2.0.0-beta13.md
@@ -1,0 +1,4 @@
+## [2.0.0-beta13](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-03-19..2023-07-07) - 2023-07-07
+
+## New Feature
+* Add `MdcAdapter` for Monix to properly share context through `MDC` with `Task` and `Local` from Monix (#438)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.0.0-SNAPSHOT"
+ThisBuild / version := "2.0.0-beta13"


### PR DESCRIPTION
# logger-f v2.0.0-beta13
## [2.0.0-beta13](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-03-19..2023-07-07) - 2023-07-07

## New Feature
* Add `MdcAdapter` for Monix to properly share context through `MDC` with `Task` and `Local` from Monix (#438)
