### PR TITLE
Close #442 - [`logger-f-logback-mdc-monix3`] Rename `MonixMdcAdapter` to `Monix3MdcAdapter`

### DIFF
--- a/modules/logger-f-logback-mdc-monix3/shared/src/main/scala/loggerf/logger/logback/Monix3MdcAdapter.scala
+++ b/modules/logger-f-logback-mdc-monix3/shared/src/main/scala/loggerf/logger/logback/Monix3MdcAdapter.scala
@@ -10,7 +10,7 @@ import scala.jdk.CollectionConverters._
 /** @author Kevin Lee
   * @since 2023-02-18
   */
-class MonixMdcAdapter extends JLoggerFMdcAdapter {
+class Monix3MdcAdapter extends JLoggerFMdcAdapter {
 
   private[this] val localContext: Local[Map[String, String]] =
     Local[Map[String, String]](Map.empty[String, String])
@@ -38,13 +38,13 @@ class MonixMdcAdapter extends JLoggerFMdcAdapter {
   override def getKeys: JSet[String] = localContext().keySet.asJava
 
 }
-object MonixMdcAdapter {
+object Monix3MdcAdapter {
 
   @SuppressWarnings(Array("org.wartremover.warts.Null"))
-  def initialize(): MonixMdcAdapter = {
+  def initialize(): Monix3MdcAdapter = {
     val field   = classOf[MDC].getDeclaredField("mdcAdapter")
     field.setAccessible(true)
-    val adapter = new MonixMdcAdapter
+    val adapter = new Monix3MdcAdapter
     field.set(null, adapter) // scalafix:ok DisableSyntax.null
     field.setAccessible(false)
     adapter

--- a/modules/logger-f-logback-mdc-monix3/shared/src/test/scala/loggerf/logger/logback/Monix3MdcAdapterSpec.scala
+++ b/modules/logger-f-logback-mdc-monix3/shared/src/test/scala/loggerf/logger/logback/Monix3MdcAdapterSpec.scala
@@ -12,14 +12,14 @@ import scala.jdk.CollectionConverters._
 /** @author Kevin Lee
   * @since 2023-07-03
   */
-object MonixMdcAdapterSpec extends Properties {
+object Monix3MdcAdapterSpec extends Properties {
 
   /*
    * Task.defaultOptions.enableLocalContextPropagation is the same as
    *   sys.props.put("monix.environment.localContextPropagation", "1")
    */
-  implicit val opts: Task.Options              = Task.defaultOptions.enableLocalContextPropagation
-  private val monixMdcAdapter: MonixMdcAdapter = MonixMdcAdapter.initialize()
+  implicit val opts: Task.Options               = Task.defaultOptions.enableLocalContextPropagation
+  private val monixMdcAdapter: Monix3MdcAdapter = Monix3MdcAdapter.initialize()
 
   override def tests: List[Test] = List(
     property("Task - MDC should be able to put and get a value", testPutAndGet),


### PR DESCRIPTION
# Summary
Close #442 - [`logger-f-logback-mdc-monix3`] Rename `MonixMdcAdapter` to `Monix3MdcAdapter`