### PR TITLE
logger-f v2.0.0-beta14

### DIFF
--- a/changelogs/2.0.0-beta14.md
+++ b/changelogs/2.0.0-beta14.md
@@ -1,0 +1,7 @@
+## [2.0.0-beta14](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-07-08..2023-07-15) - 2023-07-15
+
+## Change
+* [`logger-f-logback-mdc-monix3`] Renamed: `MonixMdcAdapter` to `Monix3MdcAdapter` (#442)
+ 
+## Bug Fix
+* Fixed: `Monix3MdcAdapter.initialize()` is broken for logback `1.4.8` (#444)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.0.0-beta13"
+ThisBuild / version := "2.0.0-beta14"


### PR DESCRIPTION
# logger-f v2.0.0-beta14
## [2.0.0-beta14](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-07-08..2023-07-15) - 2023-07-15

## Change
* [`logger-f-logback-mdc-monix3`] Renamed: `MonixMdcAdapter` to `Monix3MdcAdapter` (#442)
 
## Bug Fix
* Fixed: `Monix3MdcAdapter.initialize()` is broken for logback `1.4.8` (#444)
