### PR TITLE
logger-f v2.0.0-beta15

### DIFF
--- a/changelogs/2.0.0-beta15.md
+++ b/changelogs/2.0.0-beta15.md
@@ -1,0 +1,5 @@
+## [2.0.0-beta15](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-07-15..2023-07-15+created%3A2023-07-15) - 2023-07-15
+
+## Internal Housekeeping
+
+* Upgrade `effectie` to `2.0.0-beta10` (#448)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.0.0-SNAPSHOT"
+ThisBuild / version := "2.0.0-beta15"


### PR DESCRIPTION
# logger-f v2.0.0-beta15
## [2.0.0-beta15](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-07-15..2023-07-15+created%3A2023-07-15) - 2023-07-15

## Internal Housekeeping

* Upgrade `effectie` to `2.0.0-beta10` (#448)
