### PR TITLE
logger-f v2.0.0-beta16

### DIFF
--- a/changelogs/2.0.0-beta16.md
+++ b/changelogs/2.0.0-beta16.md
@@ -1,0 +1,5 @@
+## [2.0.0-beta16](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-07-16..2023-07-17) - 2023-07-17
+
+## New Feature
+
+* Add `initialize` method taking `Monix3MdcAdapter` in the companion object of `Monix3MdcAdapter` (#452)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.0.0-SNAPSHOT"
+ThisBuild / version := "2.0.0-beta16"


### PR DESCRIPTION
# logger-f v2.0.0-beta16
## [2.0.0-beta16](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-07-16..2023-07-17) - 2023-07-17

## New Feature

* Add `initialize` method taking `Monix3MdcAdapter` in the companion object of `Monix3MdcAdapter` (#452)
