### PR TITLE
logger-f v2.0.0-beta17

### DIFF
--- a/changelogs/2.0.0-beta17.md
+++ b/changelogs/2.0.0-beta17.md
@@ -1,0 +1,5 @@
+## [2.0.0-beta17](https://github.com/kevin-lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-07-18..2023-07-23) - 2023-07-17
+
+## Internal Housekeeping
+
+* Upgrade `effectie` to `2.0.0-beta11` (#457)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.0.0-SNAPSHOT"
+ThisBuild / version := "2.0.0-beta17"


### PR DESCRIPTION
# logger-f v2.0.0-beta17
## [2.0.0-beta17](https://github.com/kevin-lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-07-18..2023-07-23) - 2023-07-17

## Internal Housekeeping

* Upgrade `effectie` to `2.0.0-beta11` (#457)
