### PR TITLE
logger-f v2.0.0-beta18

### DIFF
--- a/changelogs/2.0.0-beta18.md
+++ b/changelogs/2.0.0-beta18.md
@@ -1,0 +1,5 @@
+## [2.0.0-beta18](https://github.com/kevin-lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+created%3A2023-09-04+closed%3A2023-07-24..2023-09-05) - 2023-09-05
+
+## New Feature
+
+* Add `Log` instance for `Try` - `Log[Try]` (#469)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.0.0-SNAPSHOT"
+ThisBuild / version := "2.0.0-beta18"


### PR DESCRIPTION
# logger-f v2.0.0-beta18
## [2.0.0-beta18](https://github.com/kevin-lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+created%3A2023-09-04+closed%3A2023-07-24..2023-09-05) - 2023-09-05

## New Feature

* Add `Log` instance for `Try` - `Log[Try]` (#469)
