### PR TITLE
Close #473 - Remove unnecessary `FxCtor` from `loggerf.instances.future.logFuture`

### DIFF
--- a/modules/logger-f-core/shared/src/main/scala-2/loggerf/instances/future.scala
+++ b/modules/logger-f-core/shared/src/main/scala-2/loggerf/instances/future.scala
@@ -12,18 +12,18 @@ import scala.concurrent.{ExecutionContext, Future}
 object future {
   @SuppressWarnings(Array("org.wartremover.warts.ImplicitParameter"))
   implicit def logFuture(
-    implicit EF: FxCtor[Future],
-    canLog: CanLog,
+    implicit canLog: CanLog,
     EC: ExecutionContext,
   ): Log[Future] =
-    new LogFuture(EF, canLog, EC)
+    new LogFuture(canLog, EC)
 
   @SuppressWarnings(Array("org.wartremover.warts.ImplicitParameter"))
   final class LogFuture(
-    override val EF: FxCtor[Future],
     override val canLog: CanLog,
     val EC: ExecutionContext,
   ) extends Log[Future] {
+
+    override val EF: FxCtor[Future] = effectie.instances.future.fxCtor.fxCtorFuture(EC)
 
     @inline override def map0[A, B](fa: Future[A])(f: A => B): Future[B] =
       fa.map(f)(EC)

--- a/modules/logger-f-core/shared/src/main/scala-3/loggerf/instances/future.scala
+++ b/modules/logger-f-core/shared/src/main/scala-3/loggerf/instances/future.scala
@@ -12,17 +12,17 @@ import scala.concurrent.{ExecutionContext, Future}
 object future {
 
   given logFuture(
-    using EF: FxCtor[Future],
-    canLog: CanLog,
+    using canLog: CanLog,
     EC: ExecutionContext,
   ): Log[Future] =
-    new LogFuture(EF, canLog, EC)
+    new LogFuture(canLog, EC)
 
   final class LogFuture(
-    override val EF: FxCtor[Future],
     override val canLog: CanLog,
     val EC: ExecutionContext,
   ) extends Log[Future] {
+
+    override val EF: FxCtor[Future] = effectie.instances.future.fxCtor.fxCtorFuture(EC)
 
     override def map0[A, B](fa: Future[A])(f: A => B): Future[B] = fa.map(f)(EC)
 


### PR DESCRIPTION
# Summary
Close #473 - Remove unnecessary `FxCtor` from `loggerf.instances.future.logFuture`