### PR TITLE
logger-f v2.0.0-beta19

### DIFF
--- a/changelogs/2.0.0-beta19.md
+++ b/changelogs/2.0.0-beta19.md
@@ -1,0 +1,7 @@
+## [2.0.0-beta19](https://github.com/kevin-lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+created%3A2023-09-05+closed%3A2023-09-05..2023-09-05) - 2023-09-06
+
+## Changed
+
+* Remove unnecessary `FxCtor` from `loggerf.instances.future.logFuture` (#473)
+
+  Since `loggerf.instances.future.LogFuture` can just have `effectie.instances.future.fxCtor.fxCtorFuture`, it's not required to have `EF: FxCtor[Future]` as a parameter of `loggerf.instances.future.logFuture`.

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.0.0-SNAPSHOT"
+ThisBuild / version := "2.0.0-beta19"


### PR DESCRIPTION
# logger-f v2.0.0-beta19
## [2.0.0-beta19](https://github.com/kevin-lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+created%3A2023-09-05+closed%3A2023-09-05..2023-09-05) - 2023-09-06

## Changed

* Remove unnecessary `FxCtor` from `loggerf.instances.future.logFuture` (#473)

  Since `loggerf.instances.future.LogFuture` can just have `effectie.instances.future.fxCtor.fxCtorFuture`, it's not required to have `EF: FxCtor[Future]` as a parameter of `loggerf.instances.future.logFuture`.
