### PR TITLE
logger-f v2.0.0-beta20

### DIFF
--- a/changelogs/2.0.0-beta20.md
+++ b/changelogs/2.0.0-beta20.md
@@ -1,0 +1,6 @@
+## [2.0.0-beta20](https://github.com/kevin-lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-09-06..2023-09-09) - 2023-09-09
+
+## Internal Housekeeping
+
+* Upgrade effectie to `2.0.0-beta12` (#478)
+* Upgrade logback to `1.4.8` (#480)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.0.0-SNAPSHOT"
+ThisBuild / version := "2.0.0-beta20"


### PR DESCRIPTION
# logger-f v2.0.0-beta20
## [2.0.0-beta20](https://github.com/kevin-lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-09-06..2023-09-09) - 2023-09-09

## Internal Housekeeping

* Upgrade effectie to `2.0.0-beta12` (#478)
* Upgrade logback to `1.4.8` (#480)
