### PR TITLE
logger-f v2.0.0-beta21

### DIFF
--- a/changelogs/2.0.0-beta21.md
+++ b/changelogs/2.0.0-beta21.md
@@ -1,0 +1,5 @@
+## [2.0.0-beta21](https://github.com/kevin-lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-09-10..2023-10-01) - 2023-10-01
+
+## Internal Housekeeping
+
+* Upgrade effectie to `2.0.0-beta13` (#488)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.0.0-SNAPSHOT"
+ThisBuild / version := "2.0.0-beta21"


### PR DESCRIPTION
# logger-f v2.0.0-beta21
## [2.0.0-beta21](https://github.com/kevin-lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-09-10..2023-10-01) - 2023-10-01

## Internal Housekeeping

* Upgrade effectie to `2.0.0-beta13` (#488)
