### PR TITLE
Close #500 - Remove unnecessary re-evaluation of `String` in `logS`

### DIFF
--- a/modules/logger-f-core/shared/src/main/scala-2/loggerf/core/Log.scala
+++ b/modules/logger-f-core/shared/src/main/scala-2/loggerf/core/Log.scala
@@ -58,7 +58,8 @@ trait Log[F[*]] {
   )(toLeveledMessage: (String => LogMessage with NotIgnorable) with LogMessage.LeveledMessage.Leveled): F[String] =
     toLeveledMessage.toLazyInput(message) match {
       case LogMessage.LeveledMessage(msg, level) =>
-        map0(EF.effectOf(canLog.getLogger(level)(msg())))(_ => message)
+        lazy val messageString = msg()
+        map0(EF.effectOf(canLog.getLogger(level)(messageString)))(_ => messageString)
     }
 
   def logS_(

--- a/modules/logger-f-core/shared/src/main/scala-3/loggerf/core/Log.scala
+++ b/modules/logger-f-core/shared/src/main/scala-3/loggerf/core/Log.scala
@@ -59,7 +59,8 @@ trait Log[F[*]] {
   def logS(message: => String)(toLeveledMessage: (String => LeveledMessage) with LeveledMessage.Leveled): F[String] =
     toLeveledMessage.toLazyInput(message) match {
       case LeveledMessage(msg, level) =>
-        map0(EF.effectOf(canLog.getLogger(level)(msg())))(_ => message)
+        lazy val messageString = msg()
+        map0(EF.effectOf(canLog.getLogger(level)(messageString)))(_ => messageString)
     }
 
   def logS_(message: => String)(toLeveledMessage: (String => LeveledMessage) with LeveledMessage.Leveled): F[Unit] =


### PR DESCRIPTION
# Summary
Close #500 - Remove unnecessary re-evaluation of `String` in `logS`