### PR TITLE
logger-f v2.0.0-beta22

### DIFF
--- a/changelogs/2.0.0-beta22.md
+++ b/changelogs/2.0.0-beta22.md
@@ -1,0 +1,25 @@
+## [2.0.0-beta22](https://github.com/kevin-lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-10-02..2023-11-07) - 2023-11-08
+
+## Change
+
+* Change the `LogMessage` parameter in the `log(F[A])` method from `NotIgnorable` to `MaybeIgnorable` (#498)
+  This could be required and useful for case like
+
+  ```scala
+  final case class Something(id: Int, name: String)
+  
+  val fa: F[Something] = ...
+  Log[F].log(fa) {
+    case Something(0, _) => ignore
+    case Something(n, name) => info(s"Something: id=$n, name=$name")
+  }
+  ```
+
+## Improvement
+
+* Remove unnecessary re-evaluation of `String` in `logS` (#500)
+  `msg()` and `message` (call-by-name) below in line 61 (Scala 2) and line 62 (Scala 3) were replaced with a single lazy evaluation.
+  
+  https://github.com/kevin-lee/logger-f/blob/47a0ad183bf4b3b847661143e31a85c302d02146/modules/logger-f-core/shared/src/main/scala-2/loggerf/core/Log.scala#L56-L62
+  
+  https://github.com/kevin-lee/logger-f/blob/47a0ad183bf4b3b847661143e31a85c302d02146/modules/logger-f-core/shared/src/main/scala-3/loggerf/core/Log.scala#L59-L63

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.0.0-SNAPSHOT"
+ThisBuild / version := "2.0.0-beta22"


### PR DESCRIPTION
# logger-f v2.0.0-beta22
## [2.0.0-beta22](https://github.com/kevin-lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-10-02..2023-11-07) - 2023-11-08

## Change

* Change the `LogMessage` parameter in the `log(F[A])` method from `NotIgnorable` to `MaybeIgnorable` (#498)
  This could be required and useful for case like

  ```scala
  final case class Something(id: Int, name: String)
  
  val fa: F[Something] = ...
  Log[F].log(fa) {
    case Something(0, _) => ignore
    case Something(n, name) => info(s"Something: id=$n, name=$name")
  }
  ```

## Improvement

* Remove unnecessary re-evaluation of `String` in `logS` (#500)
  `msg()` and `message` (call-by-name) below in line 61 (Scala 2) and line 62 (Scala 3) were replaced with a single lazy evaluation.
  
  https://github.com/kevin-lee/logger-f/blob/47a0ad183bf4b3b847661143e31a85c302d02146/modules/logger-f-core/shared/src/main/scala-2/loggerf/core/Log.scala#L56-L62
  
  https://github.com/kevin-lee/logger-f/blob/47a0ad183bf4b3b847661143e31a85c302d02146/modules/logger-f-core/shared/src/main/scala-3/loggerf/core/Log.scala#L59-L63
