### PR TITLE
logger-f v2.0.0-beta23

### DIFF
--- a/changelogs/2.0.0-beta23.md
+++ b/changelogs/2.0.0-beta23.md
@@ -1,0 +1,5 @@
+## [2.0.0-beta23](https://github.com/kevin-lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-11-08..2023-12-04) - 2023-12-05
+
+## Internal Housekeeping
+
+* [`logger-f-logback-mdc-monix3`] Bump `logback-scala-interop` to `0.2.0` (#508)


### PR DESCRIPTION
# logger-f v2.0.0-beta23
## [2.0.0-beta23](https://github.com/kevin-lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-11-08..2023-12-04) - 2023-12-05

## Internal Housekeeping

* [`logger-f-logback-mdc-monix3`] Bump `logback-scala-interop` to `0.2.0` (#508)
