### PR TITLE
Close #516 - Bump `logback` to `1.4.9` and `logback-scala-interop` to `0.3.0`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -555,13 +555,13 @@ lazy val props =
     final val ExtrasVersion = "0.25.0"
 
     final val Slf4JVersion   = "2.0.6"
-    final val LogbackVersion = "1.4.8"
+    final val LogbackVersion = "1.4.9"
 
     final val Log4sVersion = "1.10.0"
 
     final val Log4JVersion = "2.19.0"
 
-    val LogbackScalaInteropVersion = "0.2.0"
+    val LogbackScalaInteropVersion = "0.3.0"
   }
 
 lazy val libs =


### PR DESCRIPTION
# Summary
Close #516 - Bump `logback` to `1.4.9` and `logback-scala-interop` to `0.3.0`