### PR TITLE
logger-f v2.0.0-beta24

### DIFF
--- a/changelogs/2.0.0-beta24.md
+++ b/changelogs/2.0.0-beta24.md
@@ -1,0 +1,5 @@
+## [2.0.0-beta24](https://github.com/kevin-lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-12-05..2024-01-13) - 2024-01-14
+
+## Internal Housekeeping
+* Upgrade `effectie` to `2.0.0-beta14` (#514)
+* [`logger-f-logback-mdc-monix3`] Bump `logback` to `1.4.9` and `logback-scala-interop` to `0.3.0` (#516)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.0.0-SNAPSHOT"
+ThisBuild / version := "2.0.0-beta24"


### PR DESCRIPTION
# logger-f v2.0.0-beta24
## [2.0.0-beta24](https://github.com/kevin-lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-12-05..2024-01-13) - 2024-01-14

## Internal Housekeeping
* Upgrade `effectie` to `2.0.0-beta14` (#514)
* [`logger-f-logback-mdc-monix3`] Bump `logback` to `1.4.9` and `logback-scala-interop` to `0.3.0` (#516)
