### PR TITLE
logger-f v2.0.0

### DIFF
--- a/changelogs/2.0.0.md
+++ b/changelogs/2.0.0.md
@@ -1,0 +1,321 @@
+## [2.0.0](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1) - 2024-12-02
+
+* Temporarily disable `Scala.js` support (#531)
+* LoggerF v2 to support Effectie v2 (#259)
+
+It also includes all the changes in the following releases.
+
+## [2.0.0-beta1](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+created%3A%3C%3D2022-03-07) - 2022-05-03
+
+## Done
+* Upgrade `Effectie` to `v2` (#263)
+* Drop `Scalaz Effect` support (#265)
+* Move `Log` typeclass to `core` and keep the instances in the sub-projects (#266)
+* Add `F[A].log()` syntax and more to `logger-f-cats` (#272)
+* Stop releasing `logger-f-cats-effect`, `logger-f-cats-effect3` and `logger-f-monix` (#275)
+* Redesign `LeveledMessage` (#278)
+* Add `ToLog[A]` type-class to support logging type `A` (#280)
+* `ToLog` type-class instance using `cats.Show` (#283)
+* Redesign `loggerf.core.syntax` and `loggerf.cats.syntax` (#285)
+* Support `Scala.js` (#291)
+---
+
+## [2.0.0-beta2](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+created%3A2022-03-07..2022-09-24) - 2022-09-25
+
+## Done
+* Add `ignoreA(A)` syntax (#307)
+  ```scala
+  val fa: F[Option[A]] = ...
+  log(fa)(info("Not found"), ignoreA)
+  fa.log(info("Not found"), ignoreA)
+  // If None, log "Not found"
+  // If Some(value), ignore logging
+  ```
+  ```scala
+  val fab: F[Either[A, B]] = ...
+  log(fab)(ignoreA, b => info(s"It's Right($b)"))
+  fab.log(ignoreA, b => info(s"It's Right($b)"))
+  // If Left, ignore logging
+  // If Right, log
+  ```
+  ```scala
+  val fab: F[Either[A, B]] = ...
+  log(fab)(a => info(s"It's Left($a)"), ignoreA)
+  fab.log(a => info(s"It's Left($a)"), ignoreA)
+  // If Left, log
+  // If Right, ignore logging
+  ```
+* Upgrade `effectie` to `2.0.0-beta2` (#311)
+* Remove `logPure()` (#314)
+  * `logPure()` is unnecessary as `log()` should use `pureOf` internally instead of `effectOf`.
+* Upgrade log libraries (#316)
+  * `SLF4J`: `1.7.30` => `1.7.36`
+  * `Logback`: `1.2.10` => `1.2.11`
+  * `Log4j 2`: `2.17.0` => `2.19.0`
+* Remove `effectie-syntax` from the `logger-f-core` project (#318)
+* Move `loggerf.cats.instances.logF` to `loggerf.instances.cats` (#321)
+* Change `loggerf.cats.syntax` to `loggerf.syntax` (#322)
+* `loggerf.cats.show` => `loggerf.instances.show` (#326)
+* `loggerf.future.instances.logFuture` => `loggerf.instances.future.logFuture` (#329)
+
+---
+
+## [2.0.0-beta3](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2022-09-25..2022-11-17) - 2022-11-17
+
+## New Features
+* Add `ToLog` instance for `String` (`ToLog[String]`) (#334)
+* Add `ToLog.by[A](A => String): ToLog[A]` (#335)
+  ```scala
+  final case class Foo(n: Int)
+
+  val fooToLog = ToLog.by[Foo](n => s"n: ${n.toString}")
+  // ToLog[Foo]
+  fooToLog.toLogMessage(Foo(123))
+  // n: 123
+  ```
+* Add `ToLog.fromToString[A]` to construct an instance of `ToLog[A]` (#339)
+  ```scala
+  final case class Foo(n: Int)
+
+  implicit val fooToLog: ToLog[Foo] = ToLog.fromToString[Foo]
+  
+  ToLog[Foo].toLogMessage(Foo(999))
+  // Foo(999)
+  ```
+* Add `prefix(String): Prefix` and other methods to use it (#337)
+* Add `debugAWith`, `infoAWith`, `warnAWith`, `errorAWith` taking `Prefix` (#342)
+  * Scala 2
+    ```scala
+    def debugAWith[A: ToLog](prefix: Prefix): A => LogMessage with NotIgnorable
+    def infoAWith[A: ToLog](prefix: Prefix): A => LogMessage with NotIgnorable
+    def warnAWith[A: ToLog](prefix: Prefix): A => LogMessage with NotIgnorable
+    def errorAWith[A: ToLog](prefix: Prefix): A => LogMessage with NotIgnorable
+    ```
+  * Scala 3
+    ```scala
+    def debugAWith[A: ToLog](prefix: Prefix): A => LeveledMessage
+    def infoAWith[A: ToLog](prefix: Prefix): A => LeveledMessage
+    def warnAWith[A: ToLog](prefix: Prefix): A => LeveledMessage
+    def errorAWith[A: ToLog](prefix: Prefix): A => LeveledMessage
+    ```
+
+## Internal Housekeeping
+* Bump Effectie to `2.0.0-beta3` (#351)
+
+---
+
+## [2.0.0-beta4](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2022-11-18..2022-12-25) - 2022-12-25 🎄
+
+## New Features
+* Add `log_` returning `F[Unit]` (#355)
+  ```scala
+  Log[F].log_(pureOf("blah"))(info) // log info blah then returns F[Unit]
+  log_(pureOf("blah"))(info) // log info blah then returns F[Unit]
+  ```
+* Add `logS(String)(String => LogMessage with NotIgnorable): F[String]` (#358)
+  ```scala
+  logS(String)(String => LogMessage with NotIgnorable): F[String]
+  String.logS(String => LogMessage with NotIgnorable): F[String]
+  ```
+* Add `logS_(String)(String => LogMessage with NotIgnorable): F[Unit]` (#359)
+  ```scala
+  logS_(String)(String => LogMessage with NotIgnorable): F[Unit]
+  String.logS_(String => LogMessage with NotIgnorable): F[Unit]
+  ```
+
+
+## Internal Housekeeping
+* Bump Effectie to `2.0.0-beta4` (#362)
+* Bump logging libraries (#363)
+  * Slf4J `1.7.36` => `2.0.6`
+  * Logback `1.2.11` => `1.4.5`
+
+---
+
+## [2.0.0-beta5](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2022-12-26..2023-01-14) - 2023-01-14
+
+## Bug Fix
+* Fix `non-private` `val` in `GetLogger` which is for extension methods for `CanLog` (#368)
+
+
+## Internal Housekeeping
+* Upgrade `effectie` to `2.0.0-beta5` and `cats` to `2.7.0` (#372)
+* Enable Scalafmt and Scalafix checks (#370)
+
+---
+
+## [2.0.0-beta6](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-01-15..2023-01-21) - 2023-01-22
+
+## Bug Fix
+* Fix: Dynamic log level change is not applied for Slf4J logger (#376)
+
+---
+
+## [2.0.0-beta7](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-01-22..2023-02-06) - 2023-02-07
+
+## New Feature
+* Add `logger-f-test-kit` with `CanLog` instance for testing (#388)
+
+## Improvement
+* Make `logS`, `logS_` and `prefix` lazy with call-by-name and thunk (#379)
+
+---
+
+## [2.0.0-beta8](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-02-07..2023-02-07) - 2023-02-07
+
+## Bug Fix
+* `debug(Prefix)`, `info(Prefix)`, `warn(Prefix)` and `error(Prefix)` do not work with `logS` and `logS_` (#395)
+
+---
+
+## [2.0.0-beta9](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-02-08..2023-02-12) - 2023-02-12
+
+## Internal Housekeeping
+* Upgrade `effectie` to `2.0.0-beta6` (#400)
+
+---
+
+## [2.0.0-beta10](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-02-13..2023-02-26) - 2023-02-26
+
+## Update
+* Add missing `implicit` instance messages (#410)
+
+## Internal Housekeeping
+* Upgrade `effectie` to `2.0.0-beta7` (#413)
+* Bump and clean up libraries (#415)
+  * Bump: `hedgehog-extra` to `0.3.0`
+  * Remove `extras-cats` from `logger-f-cats` and `logger-f-test-kit` as it's not used by them
+
+---
+
+## [2.0.0-beta11](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-02-27..2023-03-08) - 2023-03-08
+
+## Internal Housekeeping
+* Upgrade `effectie` to `2.0.0-beta8` (#420)
+
+---
+
+## [2.0.0-beta12](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-03-09..2023-03-18) - 2023-03-18
+
+## Internal Housekeeping
+* Upgrade `effectie` to `2.0.0-beta9` (#428)
+
+---
+
+## [2.0.0-beta13](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-03-19..2023-07-07) - 2023-07-07
+
+## New Feature
+* Add `MdcAdapter` for Monix to properly share context through `MDC` with `Task` and `Local` from Monix (#438)
+
+---
+
+## [2.0.0-beta14](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-07-08..2023-07-15) - 2023-07-15
+
+## Change
+* [`logger-f-logback-mdc-monix3`] Renamed: `MonixMdcAdapter` to `Monix3MdcAdapter` (#442)
+
+## Bug Fix
+* Fixed: `Monix3MdcAdapter.initialize()` is broken for logback `1.4.8` (#444)
+
+---
+
+## [2.0.0-beta15](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-07-15..2023-07-15+created%3A2023-07-15) - 2023-07-15
+
+## Internal Housekeeping
+
+* Upgrade `effectie` to `2.0.0-beta10` (#448)
+
+---
+
+## [2.0.0-beta16](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-07-16..2023-07-17) - 2023-07-17
+
+## New Feature
+
+* Add `initialize` method taking `Monix3MdcAdapter` in the companion object of `Monix3MdcAdapter` (#452)
+
+---
+
+## [2.0.0-beta17](https://github.com/kevin-lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-07-18..2023-07-23) - 2023-07-23
+
+## Internal Housekeeping
+
+* Upgrade `effectie` to `2.0.0-beta11` (#457)
+
+---
+
+## [2.0.0-beta18](https://github.com/kevin-lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+created%3A2023-09-04+closed%3A2023-07-24..2023-09-05) - 2023-09-05
+
+## New Feature
+
+* Add `Log` instance for `Try` - `Log[Try]` (#469)
+
+---
+
+## [2.0.0-beta19](https://github.com/kevin-lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+created%3A2023-09-05+closed%3A2023-09-05..2023-09-05) - 2023-09-06
+
+## Changed
+
+* Remove unnecessary `FxCtor` from `loggerf.instances.future.logFuture` (#473)
+
+  Since `loggerf.instances.future.LogFuture` can just have `effectie.instances.future.fxCtor.fxCtorFuture`, it's not required to have `EF: FxCtor[Future]` as a parameter of `loggerf.instances.future.logFuture`.
+
+---
+
+## [2.0.0-beta20](https://github.com/kevin-lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-09-06..2023-09-09) - 2023-09-09
+
+## Internal Housekeeping
+
+* Upgrade effectie to `2.0.0-beta12` (#478)
+* Upgrade logback to `1.4.8` (#480)
+
+---
+
+## [2.0.0-beta21](https://github.com/kevin-lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-09-10..2023-10-01) - 2023-10-01
+
+## Internal Housekeeping
+
+* Upgrade effectie to `2.0.0-beta13` (#488)
+
+---
+
+## [2.0.0-beta22](https://github.com/kevin-lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-10-02..2023-11-07) - 2023-11-08
+
+## Change
+
+* Change the `LogMessage` parameter in the `log(F[A])` method from `NotIgnorable` to `MaybeIgnorable` (#498)
+  This could be required and useful for case like
+
+  ```scala
+  final case class Something(id: Int, name: String)
+  
+  val fa: F[Something] = ...
+  Log[F].log(fa) {
+    case Something(0, _) => ignore
+    case Something(n, name) => info(s"Something: id=$n, name=$name")
+  }
+  ```
+
+## Improvement
+
+* Remove unnecessary re-evaluation of `String` in `logS` (#500)
+  `msg()` and `message` (call-by-name) below in line 61 (Scala 2) and line 62 (Scala 3) were replaced with a single lazy evaluation.
+
+  https://github.com/kevin-lee/logger-f/blob/47a0ad183bf4b3b847661143e31a85c302d02146/modules/logger-f-core/shared/src/main/scala-2/loggerf/core/Log.scala#L56-L62
+
+  https://github.com/kevin-lee/logger-f/blob/47a0ad183bf4b3b847661143e31a85c302d02146/modules/logger-f-core/shared/src/main/scala-3/loggerf/core/Log.scala#L59-L63
+
+---
+
+## [2.0.0-beta23](https://github.com/kevin-lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-11-08..2023-12-04) - 2023-12-05
+
+## Internal Housekeeping
+
+* [`logger-f-logback-mdc-monix3`] Bump `logback-scala-interop` to `0.2.0` (#508)
+
+---
+
+## [2.0.0-beta24](https://github.com/kevin-lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-12-05..2024-01-13) - 2024-01-14
+
+## Internal Housekeeping
+* Upgrade `effectie` to `2.0.0-beta14` (#514)
+* [`logger-f-logback-mdc-monix3`] Bump `logback` to `1.4.9` and `logback-scala-interop` to `0.3.0` (#516)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,0 @@
-ThisBuild / version := "2.0.0-SNAPSHOT"


### PR DESCRIPTION
# logger-f v2.0.0
## [2.0.0](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1) - 2024-12-02

* Temporarily disable `Scala.js` support (#531)
* LoggerF v2 to support Effectie v2 (#259)

It also includes all the changes in the following releases.

## [2.0.0-beta1](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+created%3A%3C%3D2022-03-07) - 2022-05-03

## Done
* Upgrade `Effectie` to `v2` (#263)
* Drop `Scalaz Effect` support (#265)
* Move `Log` typeclass to `core` and keep the instances in the sub-projects (#266)
* Add `F[A].log()` syntax and more to `logger-f-cats` (#272)
* Stop releasing `logger-f-cats-effect`, `logger-f-cats-effect3` and `logger-f-monix` (#275)
* Redesign `LeveledMessage` (#278)
* Add `ToLog[A]` type-class to support logging type `A` (#280)
* `ToLog` type-class instance using `cats.Show` (#283)
* Redesign `loggerf.core.syntax` and `loggerf.cats.syntax` (#285)
* Support `Scala.js` (#291)
---

## [2.0.0-beta2](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+created%3A2022-03-07..2022-09-24) - 2022-09-25

## Done
* Add `ignoreA(A)` syntax (#307)
  ```scala
  val fa: F[Option[A]] = ...
  log(fa)(info("Not found"), ignoreA)
  fa.log(info("Not found"), ignoreA)
  // If None, log "Not found"
  // If Some(value), ignore logging
  ```
  ```scala
  val fab: F[Either[A, B]] = ...
  log(fab)(ignoreA, b => info(s"It's Right($b)"))
  fab.log(ignoreA, b => info(s"It's Right($b)"))
  // If Left, ignore logging
  // If Right, log
  ```
  ```scala
  val fab: F[Either[A, B]] = ...
  log(fab)(a => info(s"It's Left($a)"), ignoreA)
  fab.log(a => info(s"It's Left($a)"), ignoreA)
  // If Left, log
  // If Right, ignore logging
  ```
* Upgrade `effectie` to `2.0.0-beta2` (#311)
* Remove `logPure()` (#314)
  * `logPure()` is unnecessary as `log()` should use `pureOf` internally instead of `effectOf`.
* Upgrade log libraries (#316)
  * `SLF4J`: `1.7.30` => `1.7.36`
  * `Logback`: `1.2.10` => `1.2.11`
  * `Log4j 2`: `2.17.0` => `2.19.0`
* Remove `effectie-syntax` from the `logger-f-core` project (#318)
* Move `loggerf.cats.instances.logF` to `loggerf.instances.cats` (#321)
* Change `loggerf.cats.syntax` to `loggerf.syntax` (#322)
* `loggerf.cats.show` => `loggerf.instances.show` (#326)
* `loggerf.future.instances.logFuture` => `loggerf.instances.future.logFuture` (#329)

---

## [2.0.0-beta3](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2022-09-25..2022-11-17) - 2022-11-17

## New Features
* Add `ToLog` instance for `String` (`ToLog[String]`) (#334)
* Add `ToLog.by[A](A => String): ToLog[A]` (#335)
  ```scala
  final case class Foo(n: Int)

  val fooToLog = ToLog.by[Foo](n => s"n: ${n.toString}")
  // ToLog[Foo]
  fooToLog.toLogMessage(Foo(123))
  // n: 123
  ```
* Add `ToLog.fromToString[A]` to construct an instance of `ToLog[A]` (#339)
  ```scala
  final case class Foo(n: Int)

  implicit val fooToLog: ToLog[Foo] = ToLog.fromToString[Foo]
  
  ToLog[Foo].toLogMessage(Foo(999))
  // Foo(999)
  ```
* Add `prefix(String): Prefix` and other methods to use it (#337)
* Add `debugAWith`, `infoAWith`, `warnAWith`, `errorAWith` taking `Prefix` (#342)
  * Scala 2
    ```scala
    def debugAWith[A: ToLog](prefix: Prefix): A => LogMessage with NotIgnorable
    def infoAWith[A: ToLog](prefix: Prefix): A => LogMessage with NotIgnorable
    def warnAWith[A: ToLog](prefix: Prefix): A => LogMessage with NotIgnorable
    def errorAWith[A: ToLog](prefix: Prefix): A => LogMessage with NotIgnorable
    ```
  * Scala 3
    ```scala
    def debugAWith[A: ToLog](prefix: Prefix): A => LeveledMessage
    def infoAWith[A: ToLog](prefix: Prefix): A => LeveledMessage
    def warnAWith[A: ToLog](prefix: Prefix): A => LeveledMessage
    def errorAWith[A: ToLog](prefix: Prefix): A => LeveledMessage
    ```

## Internal Housekeeping
* Bump Effectie to `2.0.0-beta3` (#351)

---

## [2.0.0-beta4](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2022-11-18..2022-12-25) - 2022-12-25 🎄

## New Features
* Add `log_` returning `F[Unit]` (#355)
  ```scala
  Log[F].log_(pureOf("blah"))(info) // log info blah then returns F[Unit]
  log_(pureOf("blah"))(info) // log info blah then returns F[Unit]
  ```
* Add `logS(String)(String => LogMessage with NotIgnorable): F[String]` (#358)
  ```scala
  logS(String)(String => LogMessage with NotIgnorable): F[String]
  String.logS(String => LogMessage with NotIgnorable): F[String]
  ```
* Add `logS_(String)(String => LogMessage with NotIgnorable): F[Unit]` (#359)
  ```scala
  logS_(String)(String => LogMessage with NotIgnorable): F[Unit]
  String.logS_(String => LogMessage with NotIgnorable): F[Unit]
  ```


## Internal Housekeeping
* Bump Effectie to `2.0.0-beta4` (#362)
* Bump logging libraries (#363)
  * Slf4J `1.7.36` => `2.0.6`
  * Logback `1.2.11` => `1.4.5`

---

## [2.0.0-beta5](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2022-12-26..2023-01-14) - 2023-01-14

## Bug Fix
* Fix `non-private` `val` in `GetLogger` which is for extension methods for `CanLog` (#368)


## Internal Housekeeping
* Upgrade `effectie` to `2.0.0-beta5` and `cats` to `2.7.0` (#372)
* Enable Scalafmt and Scalafix checks (#370)

---

## [2.0.0-beta6](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-01-15..2023-01-21) - 2023-01-22

## Bug Fix
* Fix: Dynamic log level change is not applied for Slf4J logger (#376)

---

## [2.0.0-beta7](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-01-22..2023-02-06) - 2023-02-07

## New Feature
* Add `logger-f-test-kit` with `CanLog` instance for testing (#388)

## Improvement
* Make `logS`, `logS_` and `prefix` lazy with call-by-name and thunk (#379)

---

## [2.0.0-beta8](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-02-07..2023-02-07) - 2023-02-07

## Bug Fix
* `debug(Prefix)`, `info(Prefix)`, `warn(Prefix)` and `error(Prefix)` do not work with `logS` and `logS_` (#395)

---

## [2.0.0-beta9](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-02-08..2023-02-12) - 2023-02-12

## Internal Housekeeping
* Upgrade `effectie` to `2.0.0-beta6` (#400)

---

## [2.0.0-beta10](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-02-13..2023-02-26) - 2023-02-26

## Update
* Add missing `implicit` instance messages (#410)

## Internal Housekeeping
* Upgrade `effectie` to `2.0.0-beta7` (#413)
* Bump and clean up libraries (#415)
  * Bump: `hedgehog-extra` to `0.3.0`
  * Remove `extras-cats` from `logger-f-cats` and `logger-f-test-kit` as it's not used by them

---

## [2.0.0-beta11](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-02-27..2023-03-08) - 2023-03-08

## Internal Housekeeping
* Upgrade `effectie` to `2.0.0-beta8` (#420)

---

## [2.0.0-beta12](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-03-09..2023-03-18) - 2023-03-18

## Internal Housekeeping
* Upgrade `effectie` to `2.0.0-beta9` (#428)

---

## [2.0.0-beta13](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-03-19..2023-07-07) - 2023-07-07

## New Feature
* Add `MdcAdapter` for Monix to properly share context through `MDC` with `Task` and `Local` from Monix (#438)

---

## [2.0.0-beta14](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-07-08..2023-07-15) - 2023-07-15

## Change
* [`logger-f-logback-mdc-monix3`] Renamed: `MonixMdcAdapter` to `Monix3MdcAdapter` (#442)

## Bug Fix
* Fixed: `Monix3MdcAdapter.initialize()` is broken for logback `1.4.8` (#444)

---

## [2.0.0-beta15](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-07-15..2023-07-15+created%3A2023-07-15) - 2023-07-15

## Internal Housekeeping

* Upgrade `effectie` to `2.0.0-beta10` (#448)

---

## [2.0.0-beta16](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-07-16..2023-07-17) - 2023-07-17

## New Feature

* Add `initialize` method taking `Monix3MdcAdapter` in the companion object of `Monix3MdcAdapter` (#452)

---

## [2.0.0-beta17](https://github.com/kevin-lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-07-18..2023-07-23) - 2023-07-23

## Internal Housekeeping

* Upgrade `effectie` to `2.0.0-beta11` (#457)

---

## [2.0.0-beta18](https://github.com/kevin-lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+created%3A2023-09-04+closed%3A2023-07-24..2023-09-05) - 2023-09-05

## New Feature

* Add `Log` instance for `Try` - `Log[Try]` (#469)

---

## [2.0.0-beta19](https://github.com/kevin-lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+created%3A2023-09-05+closed%3A2023-09-05..2023-09-05) - 2023-09-06

## Changed

* Remove unnecessary `FxCtor` from `loggerf.instances.future.logFuture` (#473)

  Since `loggerf.instances.future.LogFuture` can just have `effectie.instances.future.fxCtor.fxCtorFuture`, it's not required to have `EF: FxCtor[Future]` as a parameter of `loggerf.instances.future.logFuture`.

---

## [2.0.0-beta20](https://github.com/kevin-lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-09-06..2023-09-09) - 2023-09-09

## Internal Housekeeping

* Upgrade effectie to `2.0.0-beta12` (#478)
* Upgrade logback to `1.4.8` (#480)

---

## [2.0.0-beta21](https://github.com/kevin-lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-09-10..2023-10-01) - 2023-10-01

## Internal Housekeeping

* Upgrade effectie to `2.0.0-beta13` (#488)

---

## [2.0.0-beta22](https://github.com/kevin-lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-10-02..2023-11-07) - 2023-11-08

## Change

* Change the `LogMessage` parameter in the `log(F[A])` method from `NotIgnorable` to `MaybeIgnorable` (#498)
  This could be required and useful for case like

  ```scala
  final case class Something(id: Int, name: String)
  
  val fa: F[Something] = ...
  Log[F].log(fa) {
    case Something(0, _) => ignore
    case Something(n, name) => info(s"Something: id=$n, name=$name")
  }
  ```

## Improvement

* Remove unnecessary re-evaluation of `String` in `logS` (#500)
  `msg()` and `message` (call-by-name) below in line 61 (Scala 2) and line 62 (Scala 3) were replaced with a single lazy evaluation.

  https://github.com/kevin-lee/logger-f/blob/47a0ad183bf4b3b847661143e31a85c302d02146/modules/logger-f-core/shared/src/main/scala-2/loggerf/core/Log.scala#L56-L62

  https://github.com/kevin-lee/logger-f/blob/47a0ad183bf4b3b847661143e31a85c302d02146/modules/logger-f-core/shared/src/main/scala-3/loggerf/core/Log.scala#L59-L63

---

## [2.0.0-beta23](https://github.com/kevin-lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-11-08..2023-12-04) - 2023-12-05

## Internal Housekeeping

* [`logger-f-logback-mdc-monix3`] Bump `logback-scala-interop` to `0.2.0` (#508)

---

## [2.0.0-beta24](https://github.com/kevin-lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1+closed%3A2023-12-05..2024-01-13) - 2024-01-14

## Internal Housekeeping
* Upgrade `effectie` to `2.0.0-beta14` (#514)
* [`logger-f-logback-mdc-monix3`] Bump `logback` to `1.4.9` and `logback-scala-interop` to `0.3.0` (#516)
