### PR TITLE
logger-f v2.0.1

### DIFF
--- a/changelogs/2.0.1.md
+++ b/changelogs/2.0.1.md
@@ -1,0 +1,3 @@
+## [2.0.1](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1-1) - 2024-12-03
+
+* [`logger-f-logback-mdc-monix3`] Bump `logback-scala-interop` to `0.4.0` and `logback` to `1.4.10` (#534)


### PR DESCRIPTION
# logger-f v2.0.1
## [2.0.1](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1-1) - 2024-12-03

* [`logger-f-logback-mdc-monix3`] Bump `logback-scala-interop` to `0.4.0` and `logback` to `1.4.10` (#534)
