### PR TITLE
logger-f v2.0.2

### DIFF
--- a/changelogs/2.0.2.md
+++ b/changelogs/2.0.2.md
@@ -1,0 +1,3 @@
+## [2.0.2](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1-2) - 2024-12-05
+
+* [`logger-f-logback-mdc-monix3`] Bump `logback-scala-interop` to `0.5.0` and `logback` to `1.4.11` (#538)


### PR DESCRIPTION
# logger-f v2.0.2
## [2.0.2](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1-2) - 2024-12-05

* [`logger-f-logback-mdc-monix3`] Bump `logback-scala-interop` to `0.5.0` and `logback` to `1.4.11` (#538)
