### PR TITLE
logger-f v2.0.3

### DIFF
--- a/changelogs/2.0.3.md
+++ b/changelogs/2.0.3.md
@@ -1,0 +1,5 @@
+## [2.0.3](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1-3) - 2024-12-09
+
+* [`logger-f-logback-mdc-monix3`] Bump `logback-scala-interop` to `0.6.0` and `logback` to `1.4.12` (#541)
+* Fix discard non-unit value (#543)
+* Upgrade `effectie` to `2.0.0` (#545)


### PR DESCRIPTION
# logger-f v2.0.3
## [2.0.3](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1-3) - 2024-12-09

* [`logger-f-logback-mdc-monix3`] Bump `logback-scala-interop` to `0.6.0` and `logback` to `1.4.12` (#541)
* Fix discard non-unit value (#543)
* Upgrade `effectie` to `2.0.0` (#545)
