### PR TITLE
logger-f v2.0.4

### DIFF
--- a/changelogs/2.0.4.md
+++ b/changelogs/2.0.4.md
@@ -1,0 +1,3 @@
+## [2.0.4](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1-4) - 2024-12-11
+
+* [`logger-f-logback-mdc-monix3`] Bump `logback-scala-interop` to `0.7.0` and `logback` to `1.4.13` (#548)


### PR DESCRIPTION
# logger-f v2.0.4
## [2.0.4](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1-4) - 2024-12-11

* [`logger-f-logback-mdc-monix3`] Bump `logback-scala-interop` to `0.7.0` and `logback` to `1.4.13` (#548)
