### PR TITLE
logger-f v2.0.5

### DIFF
--- a/changelogs/2.0.5.md
+++ b/changelogs/2.0.5.md
@@ -1,0 +1,3 @@
+## [2.0.5](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1-5) - 2024-12-13
+
+* [`logger-f-logback-mdc-monix3`] Bump `logback-scala-interop` to `0.8.0` and `logback` to `1.4.14` (#551)


### PR DESCRIPTION
# logger-f v2.0.5
## [2.0.5](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1-5) - 2024-12-13

* [`logger-f-logback-mdc-monix3`] Bump `logback-scala-interop` to `0.8.0` and `logback` to `1.4.14` (#551)
