### PR TITLE
Close #554 - [`logger-f-logback-mdc-monix3`] Bump `logback-scala-interop` to `1.0.0` and `logback` to `1.5.0`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -555,13 +555,13 @@ lazy val props =
     final val ExtrasVersion = "0.25.0"
 
     final val Slf4JVersion   = "2.0.6"
-    final val LogbackVersion = "1.4.14"
+    final val LogbackVersion = "1.5.0"
 
     final val Log4sVersion = "1.10.0"
 
     final val Log4JVersion = "2.19.0"
 
-    val LogbackScalaInteropVersion = "0.8.0"
+    val LogbackScalaInteropVersion = "1.0.0"
   }
 
 lazy val libs =


### PR DESCRIPTION
# Summary
Close #554 - [`logger-f-logback-mdc-monix3`] Bump `logback-scala-interop` to `1.0.0` and `logback` to `1.5.0`