### PR TITLE
logger-f v2.1.0

### DIFF
--- a/changelogs/2.1.0.md
+++ b/changelogs/2.1.0.md
@@ -1,0 +1,3 @@
+## [2.1.0](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1-6) - 2024-12-16
+
+* [`logger-f-logback-mdc-monix3`] Bump `logback-scala-interop` to `1.0.0` and `logback` to `1.5.0` (#554)


### PR DESCRIPTION
# logger-f v2.1.0
## [2.1.0](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1-6) - 2024-12-16

* [`logger-f-logback-mdc-monix3`] Bump `logback-scala-interop` to `1.0.0` and `logback` to `1.5.0` (#554)
