### PR TITLE
logger-f v2.1.1

### DIFF
--- a/changelogs/2.1.1.md
+++ b/changelogs/2.1.1.md
@@ -1,0 +1,3 @@
+## [2.1.1](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1-7) - 2024-12-17
+
+* [`logger-f-logback-mdc-monix3`] Bump `logback-scala-interop` to `1.1.0` and `logback` to `1.5.1` (#557)


### PR DESCRIPTION
# logger-f v2.1.1
## [2.1.1](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1-7) - 2024-12-17

* [`logger-f-logback-mdc-monix3`] Bump `logback-scala-interop` to `1.1.0` and `logback` to `1.5.1` (#557)
