### PR TITLE
logger-f v2.1.2

### DIFF
--- a/changelogs/2.1.2.md
+++ b/changelogs/2.1.2.md
@@ -1,0 +1,3 @@
+## [2.1.2](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1-8) - 2024-12-20
+
+* [`logger-f-logback-mdc-monix3`] Bump `logback-scala-interop` to `1.2.0` and `logback` to `1.5.2` (#560)


### PR DESCRIPTION
# logger-f v2.1.2
## [2.1.2](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1-8) - 2024-12-20

* [`logger-f-logback-mdc-monix3`] Bump `logback-scala-interop` to `1.2.0` and `logback` to `1.5.2` (#560)
