### PR TITLE
Close #563 - [`logger-f-logback-mdc-monix3`] Bump `logback-scala-interop` to `1.3.0` and `logback` to `1.5.3`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -554,14 +554,14 @@ lazy val props =
 
     final val ExtrasVersion = "0.25.0"
 
-    final val Slf4JVersion   = "2.0.6"
-    final val LogbackVersion = "1.5.2"
+    final val Slf4JVersion   = "2.0.12"
+    final val LogbackVersion = "1.5.3"
 
     final val Log4sVersion = "1.10.0"
 
     final val Log4JVersion = "2.19.0"
 
-    val LogbackScalaInteropVersion = "1.2.0"
+    val LogbackScalaInteropVersion = "1.3.0"
   }
 
 lazy val libs =


### PR DESCRIPTION
# Summary
Close #563 - [`logger-f-logback-mdc-monix3`] Bump `logback-scala-interop` to `1.3.0` and `logback` to `1.5.3`

Bump
- slf4j to 2.0.12
- logback to 1.5.3
- logback-scala-interop to 1.3.0
