### PR TITLE
logger-f v2.1.3

### DIFF
--- a/changelogs/2.1.3.md
+++ b/changelogs/2.1.3.md
@@ -1,0 +1,8 @@
+## [2.1.3](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1-9) - 2025-03-05
+
+## Done
+* [`logger-f-logback-mdc-monix3`] Bump `logback-scala-interop` to `1.3.0` and `logback` to `1.5.3` (#563)
+
+
+## Internal Housekeeping
+* GitHub Actions: `sbt` is missing in the build (#567)


### PR DESCRIPTION
# logger-f v2.1.3
## [2.1.3](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1-9) - 2025-03-05

## Done
* [`logger-f-logback-mdc-monix3`] Bump `logback-scala-interop` to `1.3.0` and `logback` to `1.5.3` (#563)


## Internal Housekeeping
* GitHub Actions: `sbt` is missing in the build (#567)
