### PR TITLE
logger-f v2.1.4

### DIFF
--- a/changelogs/2.1.4.md
+++ b/changelogs/2.1.4.md
@@ -1,0 +1,4 @@
+## [2.1.4](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1-10) - 2025-03-05
+
+## Done
+* [`logger-f-logback-mdc-monix3`] Bump `logback-scala-interop` to `1.4.0` and `logback` to `1.5.4` (#569)


### PR DESCRIPTION
# logger-f v2.1.4
## [2.1.4](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1-10) - 2025-03-05

## Done
* [`logger-f-logback-mdc-monix3`] Bump `logback-scala-interop` to `1.4.0` and `logback` to `1.5.4` (#569)
