### PR TITLE
Close #570 - [`logger-f-logback-mdc-monix3`] Bump `logback-scala-interop` to `1.5.0` and `logback` to `1.5.5`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -554,14 +554,14 @@ lazy val props =
 
     final val ExtrasVersion = "0.25.0"
 
-    final val Slf4JVersion   = "2.0.12"
-    final val LogbackVersion = "1.5.4"
+    final val Slf4JVersion   = "2.0.13"
+    final val LogbackVersion = "1.5.5"
 
     final val Log4sVersion = "1.10.0"
 
     final val Log4JVersion = "2.19.0"
 
-    val LogbackScalaInteropVersion = "1.4.0"
+    val LogbackScalaInteropVersion = "1.5.0"
   }
 
 lazy val libs =

--- a/modules/logger-f-logback-mdc-monix3/shared/src/main/scala/loggerf/logger/logback/Monix3MdcAdapter.scala
+++ b/modules/logger-f-logback-mdc-monix3/shared/src/main/scala/loggerf/logger/logback/Monix3MdcAdapter.scala
@@ -7,7 +7,6 @@ import org.slf4j.{LoggerFactory, MDC}
 
 import java.util.{Map => JMap, Set => JSet}
 import scala.jdk.CollectionConverters._
-import scala.util.control.NonFatal
 
 /** @author Kevin Lee
   * @since 2023-02-18
@@ -71,15 +70,8 @@ trait Monix3MdcAdapterOps {
     loggerContext: LoggerContext,
   ): Monix3MdcAdapter = {
     val adapter = initialize0(monix3MdcAdapter)
-    try {
-      val field = classOf[LoggerContext].getDeclaredField("mdcAdapter")
-      field.setAccessible(true)
-      field.set(loggerContext, adapter)
-      field.setAccessible(false)
-      adapter
-    } catch {
-      case NonFatal(_) => adapter
-    }
+    loggerContext.setMDCAdapter(adapter)
+    adapter
   }
 
 }


### PR DESCRIPTION
# Summary
Close #570 - [`logger-f-logback-mdc-monix3`] Bump `logback-scala-interop` to `1.5.0` and `logback` to `1.5.5`

Bump
- slf4j to 2.0.13
- logback to 1.5.5
- logback-scala-interop to 1.5.0

Also use `LoggerContext.setMDCAdapter` instead of reflection.
