### PR TITLE
logger-f v2.1.5

### DIFF
--- a/changelogs/2.1.5.md
+++ b/changelogs/2.1.5.md
@@ -1,0 +1,8 @@
+## [2.1.5](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1-11) - 2025-03-08
+
+## Done
+* [`logger-f-logback-mdc-monix3`] Bump `logback-scala-interop` to `1.5.0` and `logback` to `1.5.5` (#570)
+
+  Since `logback` `1.5.1`, `LoggerContext.setMDCAdapter` allows setting the inner `mdcAdapter: MDCAdapter` more than once. Previously, assigning a new `mdcAdapter` only worked when `mdcAdapter` was `null`.
+  
+  So, `LoggerContext.setMDCAdapter` is used instead of reflection to set `Monix3MdcAdapter` as `LoggerContext`'s `mdcAdapter`.


### PR DESCRIPTION
# logger-f v2.1.5
## [2.1.5](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue+is%3Aclosed+milestone%3Av2-m1-11) - 2025-03-08

## Done
* [`logger-f-logback-mdc-monix3`] Bump `logback-scala-interop` to `1.5.0` and `logback` to `1.5.5` (#570)

  Since `logback` `1.5.1`, `LoggerContext.setMDCAdapter` allows setting the inner `mdcAdapter: MDCAdapter` more than once. Previously, assigning a new `mdcAdapter` only worked when `mdcAdapter` was `null`.
  
  So, `LoggerContext.setMDCAdapter` is used instead of reflection to set `Monix3MdcAdapter` as `LoggerContext`'s `mdcAdapter`.
