### PR TITLE
logger-f v2.1.8

### DIFF
--- a/changelogs/2.1.8.md
+++ b/changelogs/2.1.8.md
@@ -1,0 +1,4 @@
+## [2.1.8](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Av2-m1-14) - 2025-03-08
+
+## Done
+* [`logger-f-logback-mdc-monix3`] Bump `logback-scala-interop` to `1.8.0` and `logback` to `1.5.8` (#573)


### PR DESCRIPTION
# logger-f v2.1.8
## [2.1.8](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Av2-m1-14) - 2025-03-08

## Done
* [`logger-f-logback-mdc-monix3`] Bump `logback-scala-interop` to `1.8.0` and `logback` to `1.5.8` (#573)
