### PR TITLE
logger-f v2.1.9

### DIFF
--- a/changelogs/2.1.9.md
+++ b/changelogs/2.1.9.md
@@ -1,0 +1,4 @@
+## [2.1.9](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Av2-m1-15) - 2025-03-08
+
+## Done
+* [`logger-f-logback-mdc-monix3`] Bump `logback-scala-interop` to `1.9.0` and `logback` to `1.5.9` (#574)


### PR DESCRIPTION
# logger-f v2.1.9
## [2.1.9](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Av2-m1-15) - 2025-03-08

## Done
* [`logger-f-logback-mdc-monix3`] Bump `logback-scala-interop` to `1.9.0` and `logback` to `1.5.9` (#574)
