### PR TITLE
logger-f v2.1.12

### DIFF
--- a/changelogs/2.1.12.md
+++ b/changelogs/2.1.12.md
@@ -1,0 +1,4 @@
+## [2.1.12](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Av2-m1-18) - 2025-03-08
+
+## Done
+* [`logger-f-logback-mdc-monix3`] Bump `logback-scala-interop` to `1.12.0` and `logback` to `1.5.12` (#577)


### PR DESCRIPTION
# logger-f v2.1.12
## [2.1.12](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Av2-m1-18) - 2025-03-08

## Done
* [`logger-f-logback-mdc-monix3`] Bump `logback-scala-interop` to `1.12.0` and `logback` to `1.5.12` (#577)
