### PR TITLE
logger-f v2.1.14

### DIFF
--- a/changelogs/2.1.14.md
+++ b/changelogs/2.1.14.md
@@ -1,0 +1,4 @@
+## [2.1.14](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Av2-m1-20) - 2025-03-09
+
+## Done
+* [`logger-f-logback-mdc-monix3`] Bump `logback-scala-interop` to `1.14.0` and `logback` to `1.5.14` (#579)


### PR DESCRIPTION
# logger-f v2.1.14
## [2.1.14](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Av2-m1-20) - 2025-03-09

## Done
* [`logger-f-logback-mdc-monix3`] Bump `logback-scala-interop` to `1.14.0` and `logback` to `1.5.14` (#579)
