### PR TITLE
Close #580 - [`logger-f-logback-mdc-monix3`] Bump `logback-scala-interop` to `1.15.0` and `logback` to `1.5.15`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -555,13 +555,13 @@ lazy val props =
     final val ExtrasVersion = "0.25.0"
 
     final val Slf4JVersion   = "2.0.15"
-    final val LogbackVersion = "1.5.14"
+    final val LogbackVersion = "1.5.15"
 
     final val Log4sVersion = "1.10.0"
 
     final val Log4JVersion = "2.19.0"
 
-    val LogbackScalaInteropVersion = "1.14.0"
+    val LogbackScalaInteropVersion = "1.15.0"
   }
 
 lazy val libs =


### PR DESCRIPTION
# Summary
Close #580 - [`logger-f-logback-mdc-monix3`] Bump `logback-scala-interop` to `1.15.0` and `logback` to `1.5.15`