### PR TITLE
Close #581 - [`logger-f-logback-mdc-monix3`] Bump `logback-scala-interop` to `1.16.0`, `slf4j` to `2.0.16` and `logback` to `1.5.16`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -554,14 +554,14 @@ lazy val props =
 
     final val ExtrasVersion = "0.25.0"
 
-    final val Slf4JVersion   = "2.0.15"
-    final val LogbackVersion = "1.5.15"
+    final val Slf4JVersion   = "2.0.16"
+    final val LogbackVersion = "1.5.16"
 
     final val Log4sVersion = "1.10.0"
 
     final val Log4JVersion = "2.19.0"
 
-    val LogbackScalaInteropVersion = "1.15.0"
+    val LogbackScalaInteropVersion = "1.16.0"
   }
 
 lazy val libs =


### PR DESCRIPTION
# Summary
Close #581 - [`logger-f-logback-mdc-monix3`] Bump `logback-scala-interop` to `1.16.0`, `slf4j` to `2.0.16` and `logback` to `1.5.16`