### PR TITLE
logger-f v2.1.16

### DIFF
--- a/changelogs/2.1.16.md
+++ b/changelogs/2.1.16.md
@@ -1,0 +1,4 @@
+## [2.1.16](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Av2-m1-22) - 2025-03-09
+
+## Done
+* [`logger-f-logback-mdc-monix3`] Bump `logback-scala-interop` to `1.16.0`, `slf4j` to `2.0.16` and `logback` to `1.5.16` (#581)


### PR DESCRIPTION
# logger-f v2.1.16
## [2.1.16](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Av2-m1-22) - 2025-03-09

## Done
* [`logger-f-logback-mdc-monix3`] Bump `logback-scala-interop` to `1.16.0`, `slf4j` to `2.0.16` and `logback` to `1.5.16` (#581)
