### PR TITLE
Fix #565 - [`logger-f-logback-mdc-monix3`] is not compatible with `logback` `1.5.17` due to changes in `slf4j` `2.0.17`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -81,6 +81,8 @@ lazy val loggerF = (project in file("."))
 //    sbtLoggingJs,
     catsJvm,
 //    catsJs,
+    slf4jMdcJvm,
+//    slf4jMdcJs,
     logbackMdcMonix3Jvm,
 //    logbackMdcMonix3Js,
     testKitJvm,
@@ -253,6 +255,24 @@ lazy val cats    =
 lazy val catsJvm = cats.jvm
 lazy val catsJs  = cats.js
 
+lazy val slf4jMdc    = module(ProjectName("slf4j-mdc"), crossProject(JVMPlatform, JSPlatform))
+  .settings(
+    description := "Logger for F[_] - A tool to set MDC's MDCAdapter",
+    libraryDependencies ++= Seq(
+      libs.slf4jApi,
+      libs.cats % Test,
+    ) ++ libs.tests.hedgehogLibs,
+    libraryDependencies := libraryDependenciesRemoveScala3Incompatible(
+      scalaVersion.value,
+      libraryDependencies.value,
+    ),
+  )
+  .dependsOn(
+    core
+  )
+lazy val slf4jMdcJvm = slf4jMdc.jvm
+lazy val slf4jMdcJs  = slf4jMdc.js
+
 lazy val logbackMdcMonix3    = module(ProjectName("logback-mdc-monix3"), crossProject(JVMPlatform, JSPlatform))
   .settings(
     description := "Logger for F[_] - logback MDC context map support for Monix 3",
@@ -270,6 +290,7 @@ lazy val logbackMdcMonix3    = module(ProjectName("logback-mdc-monix3"), crossPr
   )
   .dependsOn(
     core,
+    slf4jMdc,
     monix       % Test,
     slf4jLogger % Test,
   )
@@ -554,14 +575,14 @@ lazy val props =
 
     final val ExtrasVersion = "0.25.0"
 
-    final val Slf4JVersion   = "2.0.16"
-    final val LogbackVersion = "1.5.16"
+    final val Slf4JVersion   = "2.0.17"
+    final val LogbackVersion = "1.5.17"
 
     final val Log4sVersion = "1.10.0"
 
     final val Log4JVersion = "2.19.0"
 
-    val LogbackScalaInteropVersion = "1.16.0"
+    val LogbackScalaInteropVersion = "1.17.0"
   }
 
 lazy val libs =

--- a/modules/logger-f-logback-mdc-monix3/shared/src/main/scala/loggerf/logger/logback/Monix3MdcAdapter.scala
+++ b/modules/logger-f-logback-mdc-monix3/shared/src/main/scala/loggerf/logger/logback/Monix3MdcAdapter.scala
@@ -3,7 +3,7 @@ package loggerf.logger.logback
 import ch.qos.logback.classic.LoggerContext
 import logback_scala_interop.JLoggerFMdcAdapter
 import monix.execution.misc.Local
-import org.slf4j.{LoggerFactory, MDC}
+import org.slf4j.LoggerFactory
 
 import java.util.{Map => JMap, Set => JSet}
 import scala.jdk.CollectionConverters._
@@ -45,10 +45,7 @@ trait Monix3MdcAdapterOps {
 
   @SuppressWarnings(Array("org.wartremover.warts.Null"))
   protected def initialize0(monix3MdcAdapter: Monix3MdcAdapter): Monix3MdcAdapter = {
-    val field = classOf[MDC].getDeclaredField("mdcAdapter")
-    field.setAccessible(true)
-    field.set(null, monix3MdcAdapter) // scalafix:ok DisableSyntax.null
-    field.setAccessible(false)
+    org.slf4j.SetMdcAdapter(monix3MdcAdapter)
     monix3MdcAdapter
   }
 

--- a/modules/logger-f-slf4j-mdc/shared/src/main/scala/org/slf4j/SetMdcAdapter.scala
+++ b/modules/logger-f-slf4j-mdc/shared/src/main/scala/org/slf4j/SetMdcAdapter.scala
@@ -1,0 +1,16 @@
+package org.slf4j
+
+import org.slf4j.spi.MDCAdapter
+
+/** @author Kevin Lee
+  * @since 2025-03-09
+  */
+trait SetMdcAdapter {
+  def apply(mdcAdapter: MDCAdapter): Unit
+}
+
+object SetMdcAdapter {
+  def apply(mdcAdapter: MDCAdapter): Unit = {
+    MDC.setMDCAdapter(mdcAdapter)
+  }
+}


### PR DESCRIPTION
# Summary
Fix #565 - [`logger-f-logback-mdc-monix3`] is not compatible with `logback` `1.5.17` due to changes in `slf4j` `2.0.17`

- Update `slf4j` to `2.0.17`, `logback` to `1.5.17` and `logback-scala-interop` to `1.17.0`
- Add `slf4j` `MDC` support to set `MDCAdapter` in `MDC`
