### PR TITLE
logger-f v2.1.17

### DIFF
--- a/changelogs/2.1.17.md
+++ b/changelogs/2.1.17.md
@@ -1,0 +1,10 @@
+## [2.1.17](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Av2-m1-23) - 2025-03-09
+
+## Done
+* [`logger-f-logback-mdc-monix3`] is not compatible with `logback` `1.5.17` due to changes in `slf4j` `2.0.17` (#565)
+  * Update `slf4j` to `2.0.17`, `logback` to `1.5.17` and `logback-scala-interop` to `1.17.0`
+  * `logback` `1.5.16` uses `slf4j` `2.0.16`.
+  * `logback` `1.5.17` uses `slf4j` `2.0.17`.
+  * Due to changes introduced in `slf4j` `2.0.17`, the current logic for initializing `Monix3MdcAdapter` fails. This is not caused by `logback`'s `LoggerContext`, but rather by `MDC` from `slf4j`.
+  * This fix added `slf4j` `MDC` support to set `MDCAdapter` in `MDC`
+  * This fix updated the initialization of `MDC` to accommodate the changes in `slf4j` `2.0.17`.


### PR DESCRIPTION
# logger-f v2.1.17
## [2.1.17](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Av2-m1-23) - 2025-03-09

## Done
* [`logger-f-logback-mdc-monix3`] is not compatible with `logback` `1.5.17` due to changes in `slf4j` `2.0.17` (#565)
  * Update `slf4j` to `2.0.17`, `logback` to `1.5.17` and `logback-scala-interop` to `1.17.0`
  * `logback` `1.5.16` uses `slf4j` `2.0.16`.
  * `logback` `1.5.17` uses `slf4j` `2.0.17`.
  * Due to changes introduced in `slf4j` `2.0.17`, the current logic for initializing `Monix3MdcAdapter` fails. This is not caused by `logback`'s `LoggerContext`, but rather by `MDC` from `slf4j`.
  * This fix added `slf4j` `MDC` support to set `MDCAdapter` in `MDC`
  * This fix updated the initialization of `MDC` to accommodate the changes in `slf4j` `2.0.17`.
