### PR TITLE
Close #612 - [`logger-f-slf4j-mdc`][`logger-f-logback-mdc-monix3`] `SetMdcAdapter` and `Monix3MdcAdapter` should be compatible with older `slf4j` and `logback`

### DIFF
--- a/modules/logger-f-slf4j-mdc/shared/src/main/scala/org/slf4j/SetMdcAdapter.scala
+++ b/modules/logger-f-slf4j-mdc/shared/src/main/scala/org/slf4j/SetMdcAdapter.scala
@@ -2,6 +2,8 @@ package org.slf4j
 
 import org.slf4j.spi.MDCAdapter
 
+import scala.util.control.NonFatal
+
 /** @author Kevin Lee
   * @since 2025-03-09
   */
@@ -10,7 +12,23 @@ trait SetMdcAdapter {
 }
 
 object SetMdcAdapter {
+  @SuppressWarnings(Array("org.wartremover.warts.Null"))
   def apply(mdcAdapter: MDCAdapter): Unit = {
-    MDC.setMDCAdapter(mdcAdapter)
+    val mdcClass = classOf[MDC]
+    try {
+      val method = mdcClass.getDeclaredMethod("setMDCAdapter", classOf[MDCAdapter])
+      val _      = method.invoke(null, mdcAdapter) // scalafix:ok DisableSyntax.null
+//      println("[MDC] A method named `setMDCAdapter` was found, so it was set using `setMDCAdapter` with reflection.")
+      ()
+    } catch {
+      case NonFatal(_) =>
+//        println(
+//          "[MDC] No method named `setMDCAdapter` was found, so it will instead be set to the `mdcAdapter` field using reflection."
+//        )
+        val field = mdcClass.getDeclaredField("mdcAdapter")
+        field.setAccessible(true)
+        field.set(null, mdcAdapter) // scalafix:ok DisableSyntax.null
+        field.setAccessible(false)
+    }
   }
 }

--- a/modules/test-logger-f-logback-mdc-monix3/shared/src/test/scala/loggerf/logger/logback/Monix3MdcAdapterForLogback1_5_17_PlusAndSlf4j2_0_17Spec.scala
+++ b/modules/test-logger-f-logback-mdc-monix3/shared/src/test/scala/loggerf/logger/logback/Monix3MdcAdapterForLogback1_5_17_PlusAndSlf4j2_0_17Spec.scala
@@ -1,0 +1,8 @@
+package loggerf.logger.logback
+
+import hedgehog.runner._
+
+/** @author Kevin Lee
+  * @since 2025-03-11
+  */
+object Monix3MdcAdapterForLogback1_5_17_PlusAndSlf4j2_0_17Spec extends Properties with Monix3MdcAdapterSpecsOnly


### PR DESCRIPTION
# Summary
Close #612 - [`logger-f-slf4j-mdc`][`logger-f-logback-mdc-monix3`] `SetMdcAdapter` and `Monix3MdcAdapter` should be compatible with older `slf4j` and `logback`

- Downgrade `slf4j` to `2.0.12`
- Downgrade `logback` to `1.5.0` for `MDC` adapter
- Downgrade `logback-scala-interop` to `1.0.0`