### PR TITLE
logger-f v2.1.18

### DIFF
--- a/changelogs/2.1.18.md
+++ b/changelogs/2.1.18.md
@@ -1,0 +1,7 @@
+## [2.1.18](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Av2-m1-24) - 2025-03-12
+
+## Done
+* [`logger-f-slf4j-mdc`][`logger-f-logback-mdc-monix3`] `SetMdcAdapter`and `Monix3MdcAdapter` are now compatible with older `slf4j` and `logback` (#612)
+  * Downgraded: `slf4j` to `2.0.12`, but `SetMdcAdapter` and `Monix3MdcAdapter` can also work with the latest `slf4j` (`2.0.17` at the moment).
+  * Downgraded: `logback` to `1.5.0` for `MDC` adapter, but `SetMdcAdapter` and `Monix3MdcAdapter` can also work with the latest `logback` (`1.5.17` at the moment).
+  * Downgraded: `logback-scala-interop` to `1.0.0`


### PR DESCRIPTION
# logger-f v2.1.18
## [2.1.18](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Av2-m1-24) - 2025-03-12

## Done
* [`logger-f-slf4j-mdc`][`logger-f-logback-mdc-monix3`] `SetMdcAdapter`and `Monix3MdcAdapter` are now compatible with older `slf4j` and `logback` (#612)
  * Downgraded: `slf4j` to `2.0.12`, but `SetMdcAdapter` and `Monix3MdcAdapter` can also work with the latest `slf4j` (`2.0.17` at the moment).
  * Downgraded: `logback` to `1.5.0` for `MDC` adapter, but `SetMdcAdapter` and `Monix3MdcAdapter` can also work with the latest `logback` (`1.5.17` at the moment).
  * Downgraded: `logback-scala-interop` to `1.0.0`
