### PR TITLE
Close #617 - Bump Scala 3 to 3.1.3 - Update GitHub Actions workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
         scala:
           - { name: "Scala 2", version: "2.12.18", binary-version: "2.12", java-version: "11", java-distribution: "temurin", report: "" }
           - { name: "Scala 2", version: "2.13.11", binary-version: "2.13", java-version: "11", java-distribution: "temurin", report: "report" }
-          - { name: "Scala 3", version: "3.0.2",   binary-version: "3",    java-version: "11", java-distribution: "temurin", report: "" }
+          - { name: "Scala 3", version: "3.1.3",   binary-version: "3",    java-version: "11", java-distribution: "temurin", report: "" }
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -22,7 +22,7 @@ jobs:
         scala:
           - { name: "Scala 2", version: "2.12.18", binary-version: "2.12", java-version: "11", java-distribution: "temurin", report: "" }
           - { name: "Scala 2", version: "2.13.11", binary-version: "2.13", java-version: "11", java-distribution: "temurin", report: "" }
-    #          - { name: "Scala 3", version: "3.0.2",   binary-version: "3",    java-version: "11", java-distribution: "temurin", report: "" }
+    #          - { name: "Scala 3", version: "3.1.3",   binary-version: "3",    java-version: "11", java-distribution: "temurin", report: "" }
 
     steps:
       - uses: actions/checkout@v4.1.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         scala:
           - { name: "Scala 2", version: "2.12.18", binary-version: "2.12", java-version: "11", java-distribution: "temurin", report: "" }
           - { name: "Scala 2", version: "2.13.11", binary-version: "2.13", java-version: "11", java-distribution: "temurin", report: "" }
-          - { name: "Scala 3", version: "3.0.2",   binary-version: "3",    java-version: "11", java-distribution: "temurin", report: "" }
+          - { name: "Scala 3", version: "3.1.3",   binary-version: "3",    java-version: "11", java-distribution: "temurin", report: "" }
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
# Summary
Close #617 - Bump Scala 3 to 3.1.3 - Update GitHub Actions workflows