### PR TITLE
~logger-f v2.2.0 (Not released)~

### DIFF
--- a/changelogs/2.2.0.md
+++ b/changelogs/2.2.0.md
@@ -1,0 +1,4 @@
+## [2.2.0](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Av2-m1-25) - 2025-06-14
+
+## Done
+* Bump Scala 3 to `3.1.3`


### PR DESCRIPTION
# ~logger-f v2.2.0~
## [2.2.0](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Av2-m1-25) - 2025-06-14

## Done
* Bump Scala 3 to `3.1.3`

