### PR TITLE
logger-f v2.2.0

### DIFF
--- a/changelogs/2.2.0.md
+++ b/changelogs/2.2.0.md
@@ -1,4 +1,7 @@
-## [2.2.0](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Av2-m1-25) - 2025-06-14
+## [2.2.0](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Av2-m1-26) - 2025-06-14
 
 ## Done
 * Bump Scala 3 to `3.1.3`
+
+## Internal Housekeeping
+* `s01.oss.sonatype.org` will be sunset on the 30th of June, 2025. So it will be longer possible to publish the artifacts to s01.oss.sonatype.org. (#615)


### PR DESCRIPTION
# logger-f v2.2.0
- Fix the last one (v2.2.0) that wasn't released.

## [2.2.0](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Av2-m1-26) - 2025-06-14

## Done
* Bump Scala 3 to `3.1.3`

## Internal Housekeeping
* `s01.oss.sonatype.org` will be sunset on the 30th of June, 2025. So it will be longer possible to publish the artifacts to s01.oss.sonatype.org. (#615)
