### PR TITLE
Issue #624: Put `loggerf.instances.cats` back with `@deprecated` to guide users on how to use it without `loggerf.instances.cats`

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,6 +3,8 @@ ignore:
   - "modules/logger-f-log4s"
   - "modules/logger-f-sbt-logging"
   - "modules/logger-f-slf4j"
+  - "modules/logger-f-cats/shared/src/main/scala-2/loggerf/instances/cats.scala"
+  - "modules/logger-f-cats/shared/src/main/scala-3/loggerf/instances/cats.scala"
 
 comment:
   layout: "reach, diff, flags, files"

--- a/modules/logger-f-cats/shared/src/main/scala-2/loggerf/instances/cats.scala
+++ b/modules/logger-f-cats/shared/src/main/scala-2/loggerf/instances/cats.scala
@@ -1,0 +1,26 @@
+package loggerf.instances
+
+/** @author Kevin Lee
+  * @since 2020-04-10
+  */
+@deprecated(
+  message = _cats.DeprecatedMessage,
+  since = "2.3.0",
+)
+object cats {
+
+  @deprecated(
+    message = _cats.DeprecatedMessage,
+    since = "2.3.0",
+  )
+  def logF: Nothing = sys.error(_cats.DeprecatedMessage)
+}
+private[instances] object _cats {
+  @SuppressWarnings(Array("org.wartremover.warts.FinalVal", "org.wartremover.warts.PublicInference"))
+  final val DeprecatedMessage = // scalafix:ok DisableSyntax.noFinalVal
+    "You don't need it anymore. If your project has `cats` as a dependency, it will be automatically available.\n" +
+      "More info:\n" +
+      "`loggerf.instances.cats.LogF` has been moved to `loggerf.core.Log` with [orphan-cats](https://github.com/kevin-lee/orphan). " +
+      "So, if a project using `logger-f-core` without `logger-f-cats` has `cats` as a dependency, " +
+      "the `Log` instance provided by `logger-f` is automatically available without any extra `import`s."
+}

--- a/modules/logger-f-cats/shared/src/main/scala-3/loggerf/instances/cats.scala
+++ b/modules/logger-f-cats/shared/src/main/scala-3/loggerf/instances/cats.scala
@@ -1,0 +1,26 @@
+package loggerf.instances
+
+/** @author Kevin Lee
+  * @since 2020-04-10
+  */
+@deprecated(
+  message = _cats.DeprecatedMessage,
+  since = "2.3.0",
+)
+object cats {
+
+  @deprecated(
+    message = _cats.DeprecatedMessage,
+    since = "2.3.0",
+  )
+  def logF: Nothing = sys.error(_cats.DeprecatedMessage)
+}
+private[instances] object _cats {
+  @SuppressWarnings(Array("org.wartremover.warts.FinalVal", "org.wartremover.warts.PublicInference"))
+  final val DeprecatedMessage = // scalafix:ok DisableSyntax.noFinalVal
+    "You don't need it anymore. If your project has `cats` as a dependency, it will be automatically available.\n" +
+      "More info:\n" +
+      "`loggerf.instances.cats.LogF` has been moved to `loggerf.core.Log` with [orphan-cats](https://github.com/kevin-lee/orphan). " +
+      "So, if a project using `logger-f-core` without `logger-f-cats` has `cats` as a dependency, " +
+      "the `Log` instance provided by `logger-f` is automatically available without any extra `import`s."
+}


### PR DESCRIPTION
# Summary
Issue #624: Put `loggerf.instances.cats` back with `@deprecated` to guide users on how to use it without `loggerf.instances.cats`