### PR TITLE
Issue #624: Bump orphan to 0.5.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -650,7 +650,7 @@ lazy val props =
     val LogbackScalaInteropVersion       = "1.0.0"
     val LogbackScalaInteropLatestVersion = "1.17.0"
 
-    val OrphanVersion = "0.1.0"
+    val OrphanVersion = "0.5.0"
   }
 
 lazy val libs =


### PR DESCRIPTION
# Summary
Issue #624: Bump `orphan` to `0.5.0`