### PR TITLE
logger-f v2.3.0

### DIFF
--- a/changelogs/2.3.0.md
+++ b/changelogs/2.3.0.md
@@ -1,0 +1,27 @@
+## [2.3.0](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Av2-m1-27) - 2025-09-27
+
+## New Features
+
+* Add `log` with `Throwable` (#631)
+  
+  ```scala
+  fa.log(a => info(throwable)(s"something $a"))
+  
+  Log[F].log(fa)(a => warn(throwable)(s"something $a"))
+  
+  fAorB.log(e => error(e)(s"Some error: ${e.getMessage}"), a => ignore)
+  ```
+***
+
+## Internal Changes
+
+* Move an instance of the `Log` typeclass from `logger-f-cats` to `logger-f-core` using `orphan-cats`.
+  
+  Move `loggerf.instances.cats.LogF` to `loggerf.core.Log` with [orphan-cats](https://github.com/kevin-lee/orphan).
+  
+  So, if a project using `logger-f-core` without `logger-f-cats` has `cats` as a dependency, the `Log` instance provided by `logger-f` is automatically available without any extra `import`s.
+***
+
+## Internal Housekeeping
+
+* Bump `sbt` to `1.11.6` (#633)


### PR DESCRIPTION
# logger-f v2.3.0
## [2.3.0](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Av2-m1-27) - 2025-09-27

## New Features

* Add `log` with `Throwable` (#631)
  
  ```scala
  fa.log(a => info(throwable)(s"something $a"))
  
  Log[F].log(fa)(a => warn(throwable)(s"something $a"))
  
  fAorB.log(e => error(e)(s"Some error: ${e.getMessage}"), a => ignore)
  ```
***

## Internal Changes

* Move an instance of the `Log` typeclass from `logger-f-cats` to `logger-f-core` using `orphan-cats`.
  
  Move `loggerf.instances.cats.LogF` to `loggerf.core.Log` with [orphan-cats](https://github.com/kevin-lee/orphan).
  
  So, if a project using `logger-f-core` without `logger-f-cats` has `cats` as a dependency, the `Log` instance provided by `logger-f` is automatically available without any extra `import`s.
***

## Internal Housekeeping

* Bump `sbt` to `1.11.6` (#633)
