### PR TITLE
Close #638: Bump Scala 3 to 3.3.5 and 2.13 to 2.13.16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,8 +23,8 @@ jobs:
       matrix:
         scala:
           - { name: "Scala 2", version: "2.12.18", binary-version: "2.12", java-version: "11", java-distribution: "temurin", report: "" }
-          - { name: "Scala 2", version: "2.13.14", binary-version: "2.13", java-version: "11", java-distribution: "temurin", report: "report" }
-          - { name: "Scala 3", version: "3.1.3",   binary-version: "3",    java-version: "11", java-distribution: "temurin", report: "" }
+          - { name: "Scala 2", version: "2.13.16", binary-version: "2.13", java-version: "11", java-distribution: "temurin", report: "report" }
+          - { name: "Scala 3", version: "3.3.5",   binary-version: "3",    java-version: "11", java-distribution: "temurin", report: "" }
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -21,8 +21,8 @@ jobs:
       matrix:
         scala:
           - { name: "Scala 2", version: "2.12.18", binary-version: "2.12", java-version: "11", java-distribution: "temurin", report: "" }
-          - { name: "Scala 2", version: "2.13.14", binary-version: "2.13", java-version: "11", java-distribution: "temurin", report: "" }
-    #          - { name: "Scala 3", version: "3.1.3",   binary-version: "3",    java-version: "11", java-distribution: "temurin", report: "" }
+          - { name: "Scala 2", version: "2.13.16", binary-version: "2.13", java-version: "11", java-distribution: "temurin", report: "" }
+    #          - { name: "Scala 3", version: "3.3.5",   binary-version: "3",    java-version: "11", java-distribution: "temurin", report: "" }
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         scala:
-          - { name: "Scala 2", version: "2.13.14", binary-version: "2.13", java-version: "11", java-distribution: "temurin", report: "report" }
+          - { name: "Scala 2", version: "2.13.16", binary-version: "2.13", java-version: "11", java-distribution: "temurin", report: "report" }
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/doc-site-build-only.yml
+++ b/.github/workflows/doc-site-build-only.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         scala:
-          - { version: "2.13.14", binary-version: "2.13", java-version: "11", java-distribution: "temurin" }
+          - { version: "2.13.16", binary-version: "2.13", java-version: "11", java-distribution: "temurin" }
         node:
           - { version: "22.19.0" }
 

--- a/.github/workflows/doc-site-publish.yml
+++ b/.github/workflows/doc-site-publish.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         scala:
-          - { version: "2.13.14", binary-version: "2.13", java-version: "11", java-distribution: "temurin" }
+          - { version: "2.13.16", binary-version: "2.13", java-version: "11", java-distribution: "temurin" }
         node:
           - { version: "22.19.0" }
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,8 +23,8 @@ jobs:
       matrix:
         scala:
           - { name: "Scala 2", version: "2.12.18", binary-version: "2.12", java-version: "11", java-distribution: "temurin", report: "" }
-          - { name: "Scala 2", version: "2.13.14", binary-version: "2.13", java-version: "11", java-distribution: "temurin", report: "" }
-          - { name: "Scala 3", version: "3.1.3",   binary-version: "3",    java-version: "11", java-distribution: "temurin", report: "" }
+          - { name: "Scala 2", version: "2.13.16", binary-version: "2.13", java-version: "11", java-distribution: "temurin", report: "" }
+          - { name: "Scala 3", version: "3.3.5",   binary-version: "3",    java-version: "11", java-distribution: "temurin", report: "" }
 
     steps:
       - uses: actions/checkout@v5

--- a/build.sbt
+++ b/build.sbt
@@ -611,8 +611,8 @@ lazy val props =
     final val GitHubUsername = "Kevin-Lee"
     final val RepoName       = "logger-f"
 
-    final val Scala3Versions = List("3.1.3")
-    final val Scala2Versions = List("2.13.14", "2.12.18")
+    final val Scala3Versions = List("3.3.5")
+    final val Scala2Versions = List("2.13.16", "2.12.18")
 
 //    final val ProjectScalaVersion = Scala3Versions.head
     final val ProjectScalaVersion = Scala2Versions.head

--- a/modules/logger-f-cats/shared/src/main/scala-3/loggerf/instances/show.scala
+++ b/modules/logger-f-cats/shared/src/main/scala-3/loggerf/instances/show.scala
@@ -7,7 +7,8 @@ import loggerf.core.ToLog
   * @since 2022-02-19
   */
 trait show {
-  inline given showToLog[A: Show]: ToLog[A] = Show[A].show(_)
+  inline given showToLog[A: Show]: ToLog[A] with {
+    def toLogMessage(a: A): String = Show[A].show(a)
+  }
 }
-
 object show extends show

--- a/modules/logger-f-core/shared/src/main/scala-3/loggerf/core/ToLog.scala
+++ b/modules/logger-f-core/shared/src/main/scala-3/loggerf/core/ToLog.scala
@@ -15,5 +15,7 @@ object ToLog {
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
   def fromToString[A]: ToLog[A] = _.toString
 
-  inline given stringToLog: ToLog[String] = identity(_)
+  inline given stringToLog: ToLog[String] with {
+    def toLogMessage(a: String): String = a
+  }
 }

--- a/modules/logger-f-core/shared/src/main/scala-3/loggerf/core/syntax/LogSyntax.scala
+++ b/modules/logger-f-core/shared/src/main/scala-3/loggerf/core/syntax/LogSyntax.scala
@@ -3,9 +3,6 @@ package loggerf.core.syntax
 import loggerf.LeveledMessage
 import loggerf.Ignore
 import loggerf.core.Log
-import loggerf.instances.future.given
-
-import scala.concurrent.Future
 
 /** @author Kevin Lee
   * @since 2022-02-09

--- a/modules/test-logger-f-core/shared/src/test/scala-3/core_testing/LogWithoutCustomInstanceSpec.scala
+++ b/modules/test-logger-f-core/shared/src/test/scala-3/core_testing/LogWithoutCustomInstanceSpec.scala
@@ -16,9 +16,9 @@ object LogWithoutCustomInstanceSpec extends Properties {
   def testCompileTimeError: Result = {
     val expectedMessage =
       """
-        |  Could not find an implicit Log[util.Try].
+        |  Could not find an implicit Log[scala.util.Try].
         |  If you add [cats](https://typelevel.org/cats) library to your project,
-        |  you can automatically get `Log[util.Try]` instance provided by logger-f.
+        |  you can automatically get `Log[scala.util.Try]` instance provided by logger-f.
         |
         |  Add
         |  ---
@@ -26,11 +26,11 @@ object LogWithoutCustomInstanceSpec extends Properties {
         |  ---
         |  to build.sbt.
         |
-        |  Or you can use your own instance of `Log[util.Try]` by importing yours.
+        |  Or you can use your own instance of `Log[scala.util.Try]` by importing yours.
         |  -----
-        |  If it doesn't solve, it's probably because of missing an Fx[util.Try] instance.
+        |  If it doesn't solve, it's probably because of missing an Fx[scala.util.Try] instance.
         |
-        |  You can simply import the Fx[util.Try] instance of your effect library.
+        |  You can simply import the Fx[scala.util.Try] instance of your effect library.
         |  Please check out the message of @implicitNotFound annotation on `effectie.core.Fx`.
         |  Or please check out the following document.
         |

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,19 +3,18 @@ logLevel := sbt.Level.Warn
 addDependencyTreePlugin
 
 addSbtPlugin("com.github.sbt"  % "sbt-ci-release"  % "1.11.1")
-addSbtPlugin("org.wartremover" % "sbt-wartremover" % "3.1.6")
-//addSbtPlugin("org.wartremover" % "sbt-wartremover" % "3.0.5")
-addSbtPlugin("ch.epfl.scala"   % "sbt-scalafix"    % "0.10.4")
-addSbtPlugin("org.scalameta"   % "sbt-scalafmt"    % "2.4.6")
-addSbtPlugin("org.scoverage"   % "sbt-scoverage"   % "2.1.1")
+addSbtPlugin("org.wartremover" % "sbt-wartremover" % "3.3.5")
+addSbtPlugin("ch.epfl.scala"   % "sbt-scalafix"    % "0.14.3")
+addSbtPlugin("org.scalameta"   % "sbt-scalafmt"    % "2.5.5")
+addSbtPlugin("org.scoverage"   % "sbt-scoverage"   % "2.3.1")
 addSbtPlugin("org.scoverage"   % "sbt-coveralls"   % "1.3.2")
 addSbtPlugin("org.scalameta"   % "sbt-mdoc"        % "2.3.2")
-addSbtPlugin("io.kevinlee"     % "sbt-docusaur"    % "0.15.0")
+addSbtPlugin("io.kevinlee"     % "sbt-docusaur"    % "0.17.0")
 
 addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.16.0")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")
 
-val sbtDevOopsVersion = "3.1.0"
+val sbtDevOopsVersion = "3.2.1"
 addSbtPlugin("io.kevinlee" % "sbt-devoops-scala"     % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-sbt-extra" % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-github"    % sbtDevOopsVersion)


### PR DESCRIPTION
# Close #638: Bump Scala 3 to 3.3.5 and 2.13 to 2.13.16

Update Scala versions and dependencies, fix Scala 3 compatibility

- Update Scala `3.1.3` -> `3.3.5` and Scala `2.13.14` -> `2.13.16`
- Update `sbt-wartremover` `3.1.6` -> `3.3.5`
- Update `sbt-scalafix` `0.10.4` -> `0.14.3`
- Update `sbt-scalafmt` `2.4.6` -> `2.5.5`
- Update `sbt-scoverage` `2.1.1` -> `2.3.1`
- Update `sbt-docusaur` `0.15.0` -> `0.17.0`
- Update `sbt-devoops` `3.1.0` -> `3.2.1`

- Fix Scala 3 `ToLog` instances to use explicit method definitions
- Remove unused Future imports from `LogSyntax`

