### PR TITLE
logger-f v2.4.0

### DIFF
--- a/changelogs/2.4.0.md
+++ b/changelogs/2.4.0.md
@@ -1,0 +1,8 @@
+## [2.4.0](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Av2-m1-28) - 2025-09-28
+
+## Internal Housekeeping
+
+* Bump Scala `3` to `3.3.5` and `2.13` to `2.13.16` (#638)
+* Upgrade Docusaurus to `3.9.1` (#641)
+* Bump `orphan` to `0.5.0` (#644)
+* Bump `logback` to `1.5.18` (#647)


### PR DESCRIPTION
# logger-f v2.4.0

## [2.4.0](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Av2-m1-28) - 2025-09-28

## Internal Housekeeping

* Bump Scala `3` to `3.3.5` and `2.13` to `2.13.16` (#638)
* Upgrade Docusaurus to `3.9.1` (#641)
* Bump `orphan` to `0.5.0` (#644)
* Bump `logback` to `1.5.18` (#647)
