### PR TITLE
logger-f v2.5.0

### DIFF
--- a/changelogs/2.5.0.md
+++ b/changelogs/2.5.0.md
@@ -1,0 +1,5 @@
+## [2.5.0](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Av2-m1-29) - 2025-10-23
+
+## Internal Housekeeping
+
+* Upgrade `effectie` to `2.1.0` (#654)


### PR DESCRIPTION
# logger-f v2.5.0
## [2.5.0](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Av2-m1-29) - 2025-10-23

## Internal Housekeeping

* Upgrade `effectie` to `2.1.0` (#654)
