### PR TITLE
Close #659: Add a way to set custom log levels for Successful, ProcessingFailure and ExecFailure cases

### DIFF
--- a/modules/logger-f-doobie1/shared/src/test/scala/loggerf/doobie1/LoggerFLogHandlerSpec.scala
+++ b/modules/logger-f-doobie1/shared/src/test/scala/loggerf/doobie1/LoggerFLogHandlerSpec.scala
@@ -1,6 +1,7 @@
 package loggerf.doobie1
 
 import cats.effect._
+import cats.syntax.all._
 import doobie.util.log.{ExecFailure, Parameters, ProcessingFailure, Success}
 import effectie.instances.ce3.fx.ioFx
 import extras.hedgehog.ce3.syntax.runner._
@@ -20,13 +21,54 @@ object LoggerFLogHandlerSpec extends Properties {
   val F: IO.type = IO
 
   override def tests: List[Test] = List(
-    property("test Success log - with batch param rendering", testSuccessWithBatchParamRendering),
-    property("test Success log - without batch param rendering", testSuccessWithoutBatchParamRendering),
-    property("test ExecFailure", testExecFailure),
-    property("test ProcessingFailure", testProcessingFailure),
+    property(
+      "test the default LoggerFLogHandler[F] for Success log - with batch param rendering",
+      testDefaultLoggerFLogHandlerSuccessWithBatchParamRendering,
+    ),
+    property(
+      "test the default LoggerFLogHandler[F] for Success log - without batch param rendering",
+      testDefaultLoggerFLogHandlerSuccessWithoutBatchParamRendering,
+    ),
+    property(
+      "test LoggerFLogHandler[F] with custom log level for Success log - with batch param rendering",
+      testLoggerFLogHandlerCustomLogLevelForSuccessWithBatchParamRendering,
+    ),
+    property(
+      "test LoggerFLogHandler[F] with custom log level for Success log - without batch param rendering",
+      testLoggerFLogHandlerCustomLogLevelForSuccessWithoutBatchParamRendering,
+    ),
+    /////
+    property("test the default LoggerFLogHandler[F] for ExecFailure", testDefaultLoggerFLogHandlerExecFailure),
+    property(
+      "test LoggerFLogHandler[F] custom log level for ExecFailure",
+      testDefaultLoggerFLogHandlerCustomLogLevelForExecFailure,
+    ),
+    /////
+    property(
+      "test the default LoggerFLogHandler[F] for ProcessingFailure",
+      testDefaultLoggerFLogHandlerProcessingFailure,
+    ),
+    property(
+      "test LoggerFLogHandler[F] custom log level for ProcessingFailure",
+      testDefaultLoggerFLogHandlerCustomLogLevelForProcessingFailure,
+    ),
+    /////
+    property(
+      "test LoggerFLogHandler[F].toString",
+      testLoggerFLogHandlerToString,
+    ),
+    /////
+    property(
+      "test Show[LoggerFLogHandler.BatchParamRenderingWhenSuccessful]",
+      testLoggerFLogHandlerShowBatchParamRenderingWhenSuccessful,
+    ),
+    property(
+      "test Eq[LoggerFLogHandler.BatchParamRenderingWhenSuccessful]",
+      testLoggerFLogHandlerEqBatchParamRenderingWhenSuccessful,
+    ),
   )
 
-  def testSuccessWithBatchParamRendering: Property =
+  def testDefaultLoggerFLogHandlerSuccessWithBatchParamRendering: Property =
     for {
       columns <- Gen.string(Gen.alpha, Range.linear(3, 10)).list(Range.linear(1, 5)).log("columns")
       table   <- Gen.string(Gen.alpha, Range.linear(3, 10)).log("table")
@@ -36,6 +78,8 @@ object LoggerFLogHandlerSpec extends Properties {
       processing <- Gen.int(Range.linear(10, 3000)).log("processing")
     } yield runIO {
       implicit val canLog: CanLog4Testing = CanLog4Testing()
+
+      val (params, paramsStr) = toParamsAndParamsStr(args, LoggerFLogHandler.BatchParamRenderingWhenSuccessful.render)
 
       val expected =
         OrderedMessages(
@@ -47,7 +91,7 @@ object LoggerFLogHandlerSpec extends Properties {
                  |
                  |  SELECT ${columns.mkString(", ")} FROM $table
                  |
-                 | parameters = ${args.map(_.mkString("[", ", ", "]")).mkString("[\n   ", ",\n   ", "\n ]")}
+                 | parameters = $paramsStr
                  |      label = $label
                  |    elapsed = ${exec.toString} ms exec + ${processing.toString} ms processing (${(exec + processing).toString} ms total)
                  |""".stripMargin,
@@ -56,11 +100,11 @@ object LoggerFLogHandlerSpec extends Properties {
         )
 
       LoggerFLogHandler
-        .withBatchParamRenderingWhenSuccessful[F]
+        .defaultWithBatchParamRenderingWhenSuccessful[F]
         .run(
           Success(
             s"SELECT ${columns.mkString(", ")} FROM $table",
-            Parameters.Batch(() => args),
+            params,
             label,
             exec.milliseconds,
             processing.milliseconds,
@@ -71,7 +115,7 @@ object LoggerFLogHandlerSpec extends Properties {
       }
     }
 
-  def testSuccessWithoutBatchParamRendering: Property =
+  def testDefaultLoggerFLogHandlerSuccessWithoutBatchParamRendering: Property =
     for {
       columns <- Gen.string(Gen.alpha, Range.linear(3, 10)).list(Range.linear(1, 5)).log("columns")
       table   <- Gen.string(Gen.alpha, Range.linear(3, 10)).log("table")
@@ -81,6 +125,9 @@ object LoggerFLogHandlerSpec extends Properties {
       processing <- Gen.int(Range.linear(10, 3000)).log("processing")
     } yield runIO {
       implicit val canLog: CanLog4Testing = CanLog4Testing()
+
+      val (params, paramsStr) =
+        toParamsAndParamsStr(args, LoggerFLogHandler.BatchParamRenderingWhenSuccessful.doNotRender)
 
       val expected =
         OrderedMessages(
@@ -92,7 +139,7 @@ object LoggerFLogHandlerSpec extends Properties {
                  |
                  |  SELECT ${columns.mkString(", ")} FROM $table
                  |
-                 | parameters = <batch arguments not rendered>
+                 | parameters = $paramsStr
                  |      label = $label
                  |    elapsed = ${exec.toString} ms exec + ${processing.toString} ms processing (${(exec + processing).toString} ms total)
                  |""".stripMargin,
@@ -101,11 +148,11 @@ object LoggerFLogHandlerSpec extends Properties {
         )
 
       LoggerFLogHandler
-        .withoutBatchParamRenderingWhenSuccessful[F]
+        .defaultWithoutBatchParamRenderingWhenSuccessful[F]
         .run(
           Success(
             s"SELECT ${columns.mkString(", ")} FROM $table",
-            Parameters.Batch(() => args),
+            params,
             label,
             exec.milliseconds,
             processing.milliseconds,
@@ -116,7 +163,111 @@ object LoggerFLogHandlerSpec extends Properties {
       }
     }
 
-  def testExecFailure: Property =
+  def testLoggerFLogHandlerCustomLogLevelForSuccessWithBatchParamRendering: Property =
+    for {
+      logLevel <-
+        Gen.element1(loggerf.Level.debug, loggerf.Level.info, loggerf.Level.warn, loggerf.Level.error).log("logLevel")
+      columns  <- Gen.string(Gen.alpha, Range.linear(3, 10)).list(Range.linear(1, 5)).log("columns")
+      table    <- Gen.string(Gen.alpha, Range.linear(3, 10)).log("table")
+      args  <- Gen.string(Gen.alpha, Range.linear(3, 10)).list(Range.linear(0, 5)).list(Range.linear(0, 5)).log("args")
+      label <- Gen.string(Gen.alpha, Range.linear(3, 10)).log("label")
+      exec  <- Gen.int(Range.linear(10, 3000)).log("exec")
+      processing <- Gen.int(Range.linear(10, 3000)).log("processing")
+    } yield runIO {
+      implicit val canLog: CanLog4Testing = CanLog4Testing()
+
+      val renderBatchParams   = LoggerFLogHandler.BatchParamRenderingWhenSuccessful.render
+      val (params, paramsStr) = toParamsAndParamsStr(args, renderBatchParams)
+
+      val expected =
+        OrderedMessages(
+          Vector(
+            (
+              0,
+              logLevel,
+              s"""Successful Statement Execution:
+                 |
+                 |  SELECT ${columns.mkString(", ")} FROM $table
+                 |
+                 | parameters = $paramsStr
+                 |      label = $label
+                 |    elapsed = ${exec.toString} ms exec + ${processing.toString} ms processing (${(exec + processing).toString} ms total)
+                 |""".stripMargin,
+            )
+          )
+        )
+
+      LoggerFLogHandler[F](
+        renderBatchParams,
+        successfulLogLevel = LoggerFLogHandler.SuccessfulLogLevel(logLevel),
+      )
+        .run(
+          Success(
+            s"SELECT ${columns.mkString(", ")} FROM $table",
+            params,
+            label,
+            exec.milliseconds,
+            processing.milliseconds,
+          )
+        ) *> F {
+        val actual = canLog.getOrderedMessages
+        actual ==== expected
+      }
+    }
+
+  def testLoggerFLogHandlerCustomLogLevelForSuccessWithoutBatchParamRendering: Property =
+    for {
+      logLevel <-
+        Gen.element1(loggerf.Level.debug, loggerf.Level.info, loggerf.Level.warn, loggerf.Level.error).log("logLevel")
+      columns  <- Gen.string(Gen.alpha, Range.linear(3, 10)).list(Range.linear(1, 5)).log("columns")
+      table    <- Gen.string(Gen.alpha, Range.linear(3, 10)).log("table")
+      args  <- Gen.string(Gen.alpha, Range.linear(3, 10)).list(Range.linear(0, 5)).list(Range.linear(0, 5)).log("args")
+      label <- Gen.string(Gen.alpha, Range.linear(3, 10)).log("label")
+      exec  <- Gen.int(Range.linear(10, 3000)).log("exec")
+      processing <- Gen.int(Range.linear(10, 3000)).log("processing")
+    } yield runIO {
+      implicit val canLog: CanLog4Testing = CanLog4Testing()
+
+      val renderBatchParams   = LoggerFLogHandler.BatchParamRenderingWhenSuccessful.doNotRender
+      val (params, paramsStr) = toParamsAndParamsStr(args, renderBatchParams)
+
+      val expected =
+        OrderedMessages(
+          Vector(
+            (
+              0,
+              logLevel,
+              s"""Successful Statement Execution:
+                 |
+                 |  SELECT ${columns.mkString(", ")} FROM $table
+                 |
+                 | parameters = $paramsStr
+                 |      label = $label
+                 |    elapsed = ${exec.toString} ms exec + ${processing.toString} ms processing (${(exec + processing).toString} ms total)
+                 |""".stripMargin,
+            )
+          )
+        )
+
+      LoggerFLogHandler[F](
+        renderBatchParams,
+        successfulLogLevel = LoggerFLogHandler.SuccessfulLogLevel(logLevel),
+      )
+        .run(
+          Success(
+            s"SELECT ${columns.mkString(", ")} FROM $table",
+            params,
+            label,
+            exec.milliseconds,
+            processing.milliseconds,
+          )
+        ) *> F {
+        val actual = canLog.getOrderedMessages
+        actual ==== expected
+      }
+    }
+
+  def testDefaultLoggerFLogHandlerExecFailure: Property =
     for {
       columns <- Gen.string(Gen.alpha, Range.linear(3, 10)).list(Range.linear(1, 5)).log("columns")
       table   <- Gen.string(Gen.alpha, Range.linear(3, 10)).log("table")
@@ -126,6 +277,8 @@ object LoggerFLogHandlerSpec extends Properties {
       errMessage <- Gen.string(Gen.alpha, Range.linear(3, 10)).log("errMessage")
     } yield runIO {
       implicit val canLog: CanLog4Testing = CanLog4Testing()
+
+      val (params, paramsStr) = toParamsAndParamsStr(args, LoggerFLogHandler.BatchParamRenderingWhenSuccessful.render)
 
       val expectedException = new RuntimeException(errMessage)
 
@@ -139,7 +292,7 @@ object LoggerFLogHandlerSpec extends Properties {
                  |
                  |  SELECT ${columns.mkString(", ")} FROM $table
                  |
-                 | parameters = ${args.map(_.mkString("[", ", ", "]")).mkString("[\n   ", ",\n   ", "\n ]")}
+                 | parameters = $paramsStr
                  |      label = $label
                  |    elapsed = ${exec.toString} ms exec (failed)
                  |    failure = ${expectedException.getMessage}
@@ -149,11 +302,11 @@ object LoggerFLogHandlerSpec extends Properties {
         )
 
       LoggerFLogHandler
-        .withBatchParamRenderingWhenSuccessful[F]
+        .defaultWithBatchParamRenderingWhenSuccessful[F]
         .run(
           ExecFailure(
             s"SELECT ${columns.mkString(", ")} FROM $table",
-            Parameters.Batch(() => args),
+            params,
             label,
             exec.milliseconds,
             expectedException,
@@ -164,7 +317,61 @@ object LoggerFLogHandlerSpec extends Properties {
       }
     }
 
-  def testProcessingFailure: Property =
+  def testDefaultLoggerFLogHandlerCustomLogLevelForExecFailure: Property =
+    for {
+      logLevel <-
+        Gen.element1(loggerf.Level.debug, loggerf.Level.info, loggerf.Level.warn, loggerf.Level.error).log("logLevel")
+      columns  <- Gen.string(Gen.alpha, Range.linear(3, 10)).list(Range.linear(1, 5)).log("columns")
+      table    <- Gen.string(Gen.alpha, Range.linear(3, 10)).log("table")
+      args  <- Gen.string(Gen.alpha, Range.linear(3, 10)).list(Range.linear(0, 5)).list(Range.linear(0, 5)).log("args")
+      label <- Gen.string(Gen.alpha, Range.linear(3, 10)).log("label")
+      exec  <- Gen.int(Range.linear(10, 3000)).log("exec")
+      errMessage <- Gen.string(Gen.alpha, Range.linear(3, 10)).log("errMessage")
+    } yield runIO {
+      implicit val canLog: CanLog4Testing = CanLog4Testing()
+
+      val (params, paramsStr) = toParamsAndParamsStr(args, LoggerFLogHandler.BatchParamRenderingWhenSuccessful.render)
+
+      val expectedException = new RuntimeException(errMessage)
+
+      val expected =
+        OrderedMessages(
+          Vector(
+            (
+              0,
+              logLevel,
+              s"""Failed Statement Execution:
+                 |
+                 |  SELECT ${columns.mkString(", ")} FROM $table
+                 |
+                 | parameters = $paramsStr
+                 |      label = $label
+                 |    elapsed = ${exec.toString} ms exec (failed)
+                 |    failure = ${expectedException.getMessage}
+                 |""".stripMargin,
+            )
+          )
+        )
+
+      LoggerFLogHandler[F](
+        LoggerFLogHandler.BatchParamRenderingWhenSuccessful.render,
+        execFailureLogLevel = LoggerFLogHandler.ExecFailureLogLevel(logLevel),
+      )
+        .run(
+          ExecFailure(
+            s"SELECT ${columns.mkString(", ")} FROM $table",
+            params,
+            label,
+            exec.milliseconds,
+            expectedException,
+          )
+        ) *> F {
+        val actual = canLog.getOrderedMessages
+        actual ==== expected
+      }
+    }
+
+  def testDefaultLoggerFLogHandlerProcessingFailure: Property =
     for {
       columns <- Gen.string(Gen.alpha, Range.linear(3, 10)).list(Range.linear(1, 5)).log("columns")
       table   <- Gen.string(Gen.alpha, Range.linear(3, 10)).log("table")
@@ -175,6 +382,8 @@ object LoggerFLogHandlerSpec extends Properties {
       errMessage <- Gen.string(Gen.alpha, Range.linear(3, 10)).log("errMessage")
     } yield runIO {
       implicit val canLog: CanLog4Testing = CanLog4Testing()
+
+      val (params, paramsStr) = toParamsAndParamsStr(args, LoggerFLogHandler.BatchParamRenderingWhenSuccessful.render)
 
       val expectedException = new RuntimeException(errMessage)
 
@@ -188,7 +397,7 @@ object LoggerFLogHandlerSpec extends Properties {
                  |
                  |  SELECT ${columns.mkString(", ")} FROM $table
                  |
-                 | parameters = ${args.map(_.mkString("[", ", ", "]")).mkString("[\n   ", ",\n   ", "\n ]")}
+                 | parameters = $paramsStr
                  |      label = $label
                  |    elapsed = ${exec.toString} ms exec + ${processing.toString} ms processing (failed) (${(exec + processing).toString} ms total)
                  |    failure = ${expectedException.getMessage}
@@ -198,11 +407,11 @@ object LoggerFLogHandlerSpec extends Properties {
         )
 
       LoggerFLogHandler
-        .withBatchParamRenderingWhenSuccessful[F]
+        .defaultWithBatchParamRenderingWhenSuccessful[F]
         .run(
           ProcessingFailure(
             s"SELECT ${columns.mkString(", ")} FROM $table",
-            Parameters.Batch(() => args),
+            params,
             label,
             exec.milliseconds,
             processing.milliseconds,
@@ -214,4 +423,199 @@ object LoggerFLogHandlerSpec extends Properties {
       }
     }
 
+  def testDefaultLoggerFLogHandlerCustomLogLevelForProcessingFailure: Property =
+    for {
+      logLevel <-
+        Gen.element1(loggerf.Level.debug, loggerf.Level.info, loggerf.Level.warn, loggerf.Level.error).log("logLevel")
+      columns  <- Gen.string(Gen.alpha, Range.linear(3, 10)).list(Range.linear(1, 5)).log("columns")
+      table    <- Gen.string(Gen.alpha, Range.linear(3, 10)).log("table")
+      args  <- Gen.string(Gen.alpha, Range.linear(3, 10)).list(Range.linear(0, 5)).list(Range.linear(0, 5)).log("args")
+      label <- Gen.string(Gen.alpha, Range.linear(3, 10)).log("label")
+      exec  <- Gen.int(Range.linear(10, 3000)).log("exec")
+      processing <- Gen.int(Range.linear(10, 3000)).log("processing")
+      errMessage <- Gen.string(Gen.alpha, Range.linear(3, 10)).log("errMessage")
+    } yield runIO {
+      implicit val canLog: CanLog4Testing = CanLog4Testing()
+
+      val (params, paramsStr) = toParamsAndParamsStr(args, LoggerFLogHandler.BatchParamRenderingWhenSuccessful.render)
+
+      val expectedException = new RuntimeException(errMessage)
+
+      val expected =
+        OrderedMessages(
+          Vector(
+            (
+              0,
+              logLevel,
+              s"""Failed Resultset Processing:
+                 |
+                 |  SELECT ${columns.mkString(", ")} FROM $table
+                 |
+                 | parameters = $paramsStr
+                 |      label = $label
+                 |    elapsed = ${exec.toString} ms exec + ${processing.toString} ms processing (failed) (${(exec + processing).toString} ms total)
+                 |    failure = ${expectedException.getMessage}
+                 |""".stripMargin,
+            )
+          )
+        )
+
+      LoggerFLogHandler[F](
+        LoggerFLogHandler.BatchParamRenderingWhenSuccessful.render,
+        processingFailureLogLevel = LoggerFLogHandler.ProcessingFailureLogLevel(logLevel),
+      )
+        .run(
+          ProcessingFailure(
+            s"SELECT ${columns.mkString(", ")} FROM $table",
+            params,
+            label,
+            exec.milliseconds,
+            processing.milliseconds,
+            expectedException,
+          )
+        ) *> F {
+        val actual = canLog.getOrderedMessages
+        actual ==== expected
+      }
+    }
+
+  def testLoggerFLogHandlerToString: Property = {
+    for {
+      successfulBatchParamRendering <- Gen
+                                         .element1(
+                                           LoggerFLogHandler.BatchParamRenderingWhenSuccessful.render,
+                                           LoggerFLogHandler.BatchParamRenderingWhenSuccessful.doNotRender,
+                                         )
+                                         .log("successfulBatchParamRendering")
+      logLevelForSuccess            <- Gen
+                                         .element1(
+                                           loggerf.Level.debug,
+                                           loggerf.Level.info,
+                                           loggerf.Level.warn,
+                                           loggerf.Level.error,
+                                         )
+                                         .log("logLevelForSuccess")
+      logLevelForProcessingFailure  <- Gen
+                                         .element1(
+                                           loggerf.Level.debug,
+                                           loggerf.Level.info,
+                                           loggerf.Level.warn,
+                                           loggerf.Level.error,
+                                         )
+                                         .log("logLevelForProcessingFailure")
+      logLevelForExecFailure        <- Gen
+                                         .element1(
+                                           loggerf.Level.debug,
+                                           loggerf.Level.info,
+                                           loggerf.Level.warn,
+                                           loggerf.Level.error,
+                                         )
+                                         .log("logLevelForExecFailure")
+    } yield {
+      implicit val canLog: CanLog4Testing = CanLog4Testing()
+
+      @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+      val expected =
+        s"""LoggerFLogHandlerF(
+           |  successfulBatchParamRendering = ${successfulBatchParamRendering.show}
+           |  successfulLogLevel = ${logLevelForSuccess.toString}
+           |  processingFailureLogLevel = ${logLevelForProcessingFailure.toString}
+           |  execFailureLogLevel = ${logLevelForExecFailure.toString}
+           |)""".stripMargin
+
+      @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+      val actual = LoggerFLogHandler[F](
+        successfulBatchParamRendering,
+        LoggerFLogHandler.SuccessfulLogLevel(logLevelForSuccess),
+        LoggerFLogHandler.ProcessingFailureLogLevel(logLevelForProcessingFailure),
+        LoggerFLogHandler.ExecFailureLogLevel(logLevelForExecFailure),
+      ).toString
+
+      actual ==== expected
+    }
+  }
+
+  def testLoggerFLogHandlerShowBatchParamRenderingWhenSuccessful: Property = for {
+    batchParamRenderingWhenSuccessful <- Gen
+                                           .element1(
+                                             LoggerFLogHandler.BatchParamRenderingWhenSuccessful.render,
+                                             LoggerFLogHandler.BatchParamRenderingWhenSuccessful.doNotRender,
+                                           )
+                                           .log("batchParamRenderingWhenSuccessful")
+  } yield {
+    val expected = batchParamRenderingWhenSuccessful match {
+      case LoggerFLogHandler.BatchParamRenderingWhenSuccessful.Render =>
+        "Render batch parameters"
+      case LoggerFLogHandler.BatchParamRenderingWhenSuccessful.DoNotRender =>
+        "Do NOT render batch parameters"
+    }
+
+    val actual = batchParamRenderingWhenSuccessful.show
+    actual ==== expected
+  }
+
+  def testLoggerFLogHandlerEqBatchParamRenderingWhenSuccessful: Property = for {
+    batchParamRenderingWhenSuccessful <- Gen
+                                           .element1(
+                                             LoggerFLogHandler.BatchParamRenderingWhenSuccessful.render,
+                                             LoggerFLogHandler.BatchParamRenderingWhenSuccessful.doNotRender,
+                                           )
+                                           .log("batchParamRenderingWhenSuccessful")
+  } yield {
+    val (expectedEqualValue, expectedNotEqualValue) = batchParamRenderingWhenSuccessful match {
+      case LoggerFLogHandler.BatchParamRenderingWhenSuccessful.Render =>
+        (
+          LoggerFLogHandler.BatchParamRenderingWhenSuccessful.render,
+          LoggerFLogHandler.BatchParamRenderingWhenSuccessful.doNotRender,
+        )
+      case LoggerFLogHandler.BatchParamRenderingWhenSuccessful.DoNotRender =>
+        (
+          LoggerFLogHandler.BatchParamRenderingWhenSuccessful.doNotRender,
+          LoggerFLogHandler.BatchParamRenderingWhenSuccessful.render,
+        )
+    }
+
+    Result.all(
+      List(
+        Result.diffNamed(
+          show"$batchParamRenderingWhenSuccessful === $expectedEqualValue",
+          batchParamRenderingWhenSuccessful,
+          expectedEqualValue,
+        )(_ === _),
+        Result.diffNamed(
+          show"$batchParamRenderingWhenSuccessful =!= $expectedNotEqualValue",
+          batchParamRenderingWhenSuccessful,
+          expectedNotEqualValue,
+        )(_ =!= _),
+      )
+    )
+
+  }
+
+  @SuppressWarnings(Array("org.wartremover.warts.SizeIs"))
+  private def toParamsAndParamsStr(
+    args: List[List[String]],
+    batchParamRenderingWhenSuccessful: LoggerFLogHandler.BatchParamRenderingWhenSuccessful,
+  ): (Parameters, String) = {
+    (
+      args
+        .headOption
+        .fold[Parameters](Parameters.NonBatch(List.empty))(firstParams =>
+          if (args.length === 1) Parameters.NonBatch(firstParams) else Parameters.Batch(() => args)
+        ),
+      (batchParamRenderingWhenSuccessful, args.length) match {
+        case (LoggerFLogHandler.BatchParamRenderingWhenSuccessful.Render, 0 | 1) =>
+          args.headOption.fold("[]")(_.mkString("[", ", ", "]"))
+
+        case (LoggerFLogHandler.BatchParamRenderingWhenSuccessful.Render, _) =>
+          args.map(_.mkString("[", ", ", "]")).mkString("[\n   ", ",\n   ", "\n ]")
+
+        case (LoggerFLogHandler.BatchParamRenderingWhenSuccessful.DoNotRender, 0 | 1) =>
+          args.headOption.fold("[]")(_.mkString("[", ", ", "]"))
+
+        case (LoggerFLogHandler.BatchParamRenderingWhenSuccessful.DoNotRender, _) =>
+          "<batch arguments not rendered>"
+      },
+    )
+  }
 }


### PR DESCRIPTION
Close #659: Add a way to set custom log levels for Successful, ProcessingFailure and ExecFailure cases