### PR TITLE
logger-f v2.6.0

### DIFF
--- a/changelogs/2.6.0.md
+++ b/changelogs/2.6.0.md
@@ -1,0 +1,48 @@
+## [2.6.0](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Av2-m1-30) - 2025-10-31 🎃
+
+## New Features
+
+* Add `LoggerFLogHandler` to support doobie's `LogHandler` (#461)
+
+  `LoggerFLogHandler` is to use logger-f for `LogHandler` from doobie v1 (the latest version of v1 is ~~`1.0.0-RC4`~~`1.0.0-RC10` as of today).
+
+***
+* [`logger-f-doobie1`] Update batch param rendering in `LoggerFLogHandler` (#657)
+
+  ```
+   arguments = ...
+   label     = ...
+     elapsed = ...
+  ```
+  to
+  ```
+   parameters = ...
+        label = ...
+      elapsed = ...
+  ```
+  
+  Also, add the following constructor methods to render or ignore batch parameters when the query is successfully done,
+  
+  ~~`LoggerFLogHandler.withBatchParamRenderingWhenSuccessful[F]`~~
+  ```scala
+  LoggerFLogHandler.defaultWithBatchParamRenderingWhenSuccessful[F]
+  ```
+  
+  ~~`LoggerFLogHandler.withoutBatchParamRenderingWhenSuccessful[F]`~~
+  ```scala
+  LoggerFLogHandler.defaultWithoutBatchParamRenderingWhenSuccessful[F]
+  ```
+
+***
+* Add a way to set custom log levels for Successful, ProcessingFailure and ExecFailure cases (#659)
+
+  e.g.)
+
+  ```scala
+  LoggerFLogHandler[F](
+    LoggerFLogHandler.BatchParamRenderingWhenSuccessful.render,
+    successfulLogLevel = LoggerFLogHandler.SuccessfulLogLevel(loggerf.Level.debug),
+    processingFailureLogLevel = LoggerFLogHandler.ProcessingFailureLogLevel(loggerf.Level.info),
+    execFailureLogLevel = LoggerFLogHandler.ExecFailureLogLevel(loggerf.Level.warn),
+  )
+  ```


### PR DESCRIPTION
# logger-f v2.6.0
## [2.6.0](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Av2-m1-30) - 2025-10-31 🎃

## New Features

* Add `LoggerFLogHandler` to support doobie's `LogHandler` (#461)

  `LoggerFLogHandler` is to use logger-f for `LogHandler` from doobie v1 (the latest version of v1 is ~~`1.0.0-RC4`~~`1.0.0-RC10` as of today).

***
* [`logger-f-doobie1`] Update batch param rendering in `LoggerFLogHandler` (#657)

  ```
   arguments = ...
   label     = ...
     elapsed = ...
  ```
  to
  ```
   parameters = ...
        label = ...
      elapsed = ...
  ```
  
  Also, add the following constructor methods to render or ignore batch parameters when the query is successfully done,
  
  ~~`LoggerFLogHandler.withBatchParamRenderingWhenSuccessful[F]`~~
  ```scala
  LoggerFLogHandler.defaultWithBatchParamRenderingWhenSuccessful[F]
  ```
  
  ~~`LoggerFLogHandler.withoutBatchParamRenderingWhenSuccessful[F]`~~
  ```scala
  LoggerFLogHandler.defaultWithoutBatchParamRenderingWhenSuccessful[F]
  ```

***
* Add a way to set custom log levels for Successful, ProcessingFailure and ExecFailure cases (#659)

  e.g.)

  ```scala
  LoggerFLogHandler[F](
    LoggerFLogHandler.BatchParamRenderingWhenSuccessful.render,
    successfulLogLevel = LoggerFLogHandler.SuccessfulLogLevel(loggerf.Level.debug),
    processingFailureLogLevel = LoggerFLogHandler.ProcessingFailureLogLevel(loggerf.Level.info),
    execFailureLogLevel = LoggerFLogHandler.ExecFailureLogLevel(loggerf.Level.warn),
  )
  ```
