### PR TITLE
logger-f v2.7.0

### DIFF
--- a/changelogs/2.7.0.md
+++ b/changelogs/2.7.0.md
@@ -1,0 +1,10 @@
+## [2.7.0](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Av2-m1-31) - 2025-11-01
+
+## New Features
+
+* Support Scala.js (#529)
+
+
+## Internal Housekeeping
+
+* Bump `effectie` to `2.1.1` (#664)


### PR DESCRIPTION
# logger-f v2.7.0
## [2.7.0](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Av2-m1-31) - 2025-11-01

## New Features

* Support Scala.js (#529)


## Internal Housekeeping

* Bump `effectie` to `2.1.1` (#664)
