### PR TITLE
logger-f v2.8.0

### DIFF
--- a/changelogs/2.8.0.md
+++ b/changelogs/2.8.0.md
@@ -1,0 +1,10 @@
+## [2.8.0](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Av2-m2) - 2025-11-03
+
+## New Features
+
+* Add support for Scala Native (#433)
+
+
+## Internal Housekeeping
+
+* Bump `effectie` to `2.2.0`


### PR DESCRIPTION
# logger-f v2.8.0
## [2.8.0](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Av2-m2) - 2025-11-03

## New Features

* Add support for Scala Native (#433)


## Internal Housekeeping

* Bump `effectie` to `2.2.0`
