### PR TITLE
logger-f v2.8.1

### DIFF
--- a/changelogs/2.8.1.md
+++ b/changelogs/2.8.1.md
@@ -1,0 +1,6 @@
+## [2.8.1](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Av2-m3) - 2025-12-15
+
+
+## Internal Housekeeping
+
+* Bump `effectie` to `2.3.0` (#670)


### PR DESCRIPTION
# logger-f v2.8.1

## [2.8.1](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Av2-m3) - 2025-12-15


## Internal Housekeeping

* Bump `effectie` to `2.3.0` (#670)
