### PR TITLE
Close #684: Update `orphan` to `0.7.0` to address a deprecation issue in Scala 3.8.4 and potential compilation failures in Scala 3.10 due to inaccessible orphan given instances.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -638,7 +638,7 @@ lazy val props =
     val LogbackScalaInteropVersion       = "1.0.0"
     val LogbackScalaInteropLatestVersion = "1.17.0"
 
-    val OrphanVersion = "0.5.0"
+    val OrphanVersion = "0.7.0"
 
     val MunitVersion = "0.7.29"
 


### PR DESCRIPTION
Close #684: Update `orphan` to `0.7.0` to address a deprecation issue in Scala 3.8.4 and potential compilation failures in Scala 3.10 due to inaccessible orphan given instances.