### PR TITLE
logger-f v2.10.0

### DIFF
--- a/changelogs/2.10.0.md
+++ b/changelogs/2.10.0.md
@@ -1,0 +1,9 @@
+## [2.10.0](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Av2-m5) - 2026-06-23
+
+## Bug Fixes
+
+* Update `orphan` to `0.7.0` (#684)
+  
+  to address a deprecation issue in Scala `3.8.4` and potential compilation failures in Scala `3.10` due to inaccessible orphan `given` instances from [orphan](https://github.com/kevin-lee/orphan).
+
+  * The bug reported at kevin-lee/orphan#96


### PR DESCRIPTION
# logger-f v2.10.0
## [2.10.0](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Av2-m5) - 2026-06-23

## Bug Fixes

* Update `orphan` to `0.7.0` (#684)
  
  to address a deprecation issue in Scala `3.8.4` and potential compilation failures in Scala `3.10` due to inaccessible orphan `given` instances from [orphan](https://github.com/kevin-lee/orphan).

  * The bug reported at kevin-lee/orphan#96
