### PR TITLE
Close #689: Upgrade Scala 2.13 and libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -553,7 +553,7 @@ lazy val props =
     final val RepoName       = "logger-f"
 
     val Scala3Versions = List("3.3.5")
-    val Scala2Versions = List("2.13.17", "2.12.18")
+    val Scala2Versions = List("2.13.18", "2.12.18")
 
 //    final val ProjectScalaVersion = Scala3Versions.head
     final val ProjectScalaVersion = Scala2Versions.head
@@ -577,12 +577,12 @@ lazy val props =
 
     val HedgehogExtraVersion = "0.15.0"
 
-    val EffectieVersion = "2.3.0"
+    val EffectieVersion = "2.4.0"
 
     final val CatsVersion = "2.12.0"
 
-    val catsEffect3Version          = "3.3.14"
-    val catsEffect3ForNativeVersion = "3.7.0-RC1"
+    val catsEffect3Version          = "3.7.0"
+    val catsEffect3ForNativeVersion = "3.7.0"
 
     val Monix3Version = "3.4.0"
 
@@ -590,7 +590,7 @@ lazy val props =
 
     final val LoggerF1Version = "1.20.0"
 
-    final val ExtrasVersion = "0.49.0"
+    val ExtrasVersion = "0.53.0"
 
     val Slf4JVersion       = "2.0.12"
     val Slf4JLatestVersion = "2.0.17"

--- a/modules/logger-f-cats/jvm/src/test/scala/loggerf/instances/loggingSyntaxSpec.scala
+++ b/modules/logger-f-cats/jvm/src/test/scala/loggerf/instances/loggingSyntaxSpec.scala
@@ -102,7 +102,7 @@ object loggingSyntaxSpec extends Properties {
 
   implicit val errorLogger: ErrorLogger[Throwable] = ErrorLogger.printlnDefaultErrorLogger
 
-  private val waitFor300Millis = WaitFor(400.milliseconds)
+  private val waitForXMillis = WaitFor(500.milliseconds)
 
   object LogFASpec {
 
@@ -134,7 +134,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future]
@@ -180,7 +180,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](logMsg)
@@ -225,7 +225,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](logMsg)
@@ -271,7 +271,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](logMsg)
@@ -317,7 +317,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](logMsg)
@@ -365,7 +365,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](eab)
@@ -413,7 +413,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](eab)
@@ -461,7 +461,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](eab)
@@ -509,7 +509,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](eab)
@@ -557,7 +557,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](eab)
@@ -602,7 +602,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](logMsg)
@@ -646,7 +646,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](logMsg)
@@ -691,7 +691,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](logMsg)
@@ -739,7 +739,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](eab)
@@ -787,7 +787,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](eab)
@@ -835,7 +835,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](eab)
@@ -883,7 +883,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](eab)
@@ -931,7 +931,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](eab)
@@ -969,7 +969,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future]
@@ -1015,7 +1015,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](logMsg)
@@ -1060,7 +1060,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](logMsg)
@@ -1106,7 +1106,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](logMsg)
@@ -1152,7 +1152,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](logMsg)
@@ -1200,7 +1200,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](eab)
@@ -1248,7 +1248,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](eab)
@@ -1296,7 +1296,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](eab)
@@ -1344,7 +1344,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](eab)
@@ -1392,7 +1392,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](eab)
@@ -1437,7 +1437,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](logMsg)
@@ -1481,7 +1481,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](logMsg)
@@ -1526,7 +1526,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](logMsg)
@@ -1574,7 +1574,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](eab)
@@ -1622,7 +1622,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](eab)
@@ -1670,7 +1670,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](eab)
@@ -1718,7 +1718,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](eab)
@@ -1766,7 +1766,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](eab)
@@ -1808,7 +1808,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future]
@@ -1854,7 +1854,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](logMsg)
@@ -1899,7 +1899,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](logMsg)
@@ -1945,7 +1945,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](logMsg)
@@ -1993,7 +1993,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](eab)
@@ -2041,7 +2041,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](eab)
@@ -2089,7 +2089,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](eab)
@@ -2137,7 +2137,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](eab)
@@ -2185,7 +2185,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](eab)
@@ -2230,7 +2230,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](logMsg)
@@ -2274,7 +2274,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](logMsg)
@@ -2319,7 +2319,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](logMsg)
@@ -2367,7 +2367,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](eab)
@@ -2415,7 +2415,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](eab)
@@ -2463,7 +2463,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](eab)
@@ -2511,7 +2511,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](eab)
@@ -2559,7 +2559,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](eab)
@@ -2596,7 +2596,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future]
@@ -2642,7 +2642,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](logMsg)
@@ -2687,7 +2687,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](logMsg)
@@ -2733,7 +2733,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](logMsg)
@@ -2781,7 +2781,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](eab)
@@ -2829,7 +2829,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](eab)
@@ -2877,7 +2877,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](eab)
@@ -2925,7 +2925,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](eab)
@@ -2973,7 +2973,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](eab)
@@ -3018,7 +3018,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](logMsg)
@@ -3062,7 +3062,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](logMsg)
@@ -3107,7 +3107,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](logMsg)
@@ -3155,7 +3155,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](eab)
@@ -3203,7 +3203,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](eab)
@@ -3251,7 +3251,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](eab)
@@ -3299,7 +3299,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](eab)
@@ -3347,7 +3347,7 @@ object loggingSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
 
         runLog[Future](eab)


### PR DESCRIPTION
## Close #689: Upgrade Scala 2.13 and libraries

- `scala`: `2.13.17` => `2.13.18`
- `effectie`: `2.3.0` => `2.4.0`
- `cats-effect`: `3.3.14` => `3.7.0`
- `cats-effect` (Native): `3.7.0-RC1` => `3.7.0`
- `extras`: `0.49.0` => `0.53.0`

Also, in `loggingSyntaxSpec`, rename `waitFor300Millis` to `waitForXMillis` and bump the `WaitFor` timeout from `400.milliseconds` to `500.milliseconds` to reduce flakiness in the `Future`-based async tests.

