### PR TITLE
Update `extras` to `0.54.0` and increase async test timeouts

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -590,7 +590,7 @@ lazy val props =
 
     final val LoggerF1Version = "1.20.0"
 
-    val ExtrasVersion = "0.53.0"
+    val ExtrasVersion = "0.54.0"
 
     val Slf4JVersion       = "2.0.12"
     val Slf4JLatestVersion = "2.0.17"

--- a/modules/logger-f-cats/jvm/src/test/scala/loggerf/instances/extraSyntaxSpec.scala
+++ b/modules/logger-f-cats/jvm/src/test/scala/loggerf/instances/extraSyntaxSpec.scala
@@ -105,7 +105,7 @@ object extraSyntaxSpec extends Properties {
 
   implicit val errorLogger: ErrorLogger[Throwable] = ErrorLogger.printlnDefaultErrorLogger
 
-  private val waitFor500Millis = WaitFor(500.milliseconds)
+  private val waitForXMillis = WaitFor(600.milliseconds)
 
   def testLogSWithPrefix: Property = for {
     prefixString <- Gen.string(Gen.unicode, Range.linear(5, 20)).log("prefixString")
@@ -136,7 +136,7 @@ object extraSyntaxSpec extends Properties {
     implicit val ec: ExecutionContext =
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor500Millis) {
+    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
       import loggerf.instances.future.logFuture
       runLog[Future]
     }
@@ -173,7 +173,7 @@ object extraSyntaxSpec extends Properties {
     implicit val ec: ExecutionContext =
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor500Millis) {
+    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
       import loggerf.instances.future.logFuture
       runLog[Future]
     }
@@ -210,7 +210,7 @@ object extraSyntaxSpec extends Properties {
     implicit val ec: ExecutionContext =
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor500Millis) {
+    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
       import effectie.instances.future.fxCtor._
       import loggerf.instances.future.logFuture
       runLog[Future]
@@ -257,7 +257,7 @@ object extraSyntaxSpec extends Properties {
     implicit val ec: ExecutionContext =
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor500Millis) {
+    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
       import effectie.instances.future.fxCtor._
       import loggerf.instances.future.logFuture
       runLog[Future](logMsg)
@@ -303,7 +303,7 @@ object extraSyntaxSpec extends Properties {
     implicit val ec: ExecutionContext =
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor500Millis) {
+    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
       import effectie.instances.future.fxCtor._
       import loggerf.instances.future.logFuture
       runLog[Future](logMsg)
@@ -350,7 +350,7 @@ object extraSyntaxSpec extends Properties {
     implicit val ec: ExecutionContext =
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor500Millis) {
+    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
       import effectie.instances.future.fxCtor._
       import loggerf.instances.future.logFuture
       runLog[Future](logMsg)
@@ -397,7 +397,7 @@ object extraSyntaxSpec extends Properties {
     implicit val ec: ExecutionContext =
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor500Millis) {
+    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
       import effectie.instances.future.fxCtor._
       import loggerf.instances.future.logFuture
       runLog[Future](logMsg)
@@ -446,7 +446,7 @@ object extraSyntaxSpec extends Properties {
     implicit val ec: ExecutionContext =
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor500Millis) {
+    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
       import effectie.instances.future.fxCtor._
       import loggerf.instances.future.logFuture
       runLog[Future](eab)
@@ -495,7 +495,7 @@ object extraSyntaxSpec extends Properties {
     implicit val ec: ExecutionContext =
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor500Millis) {
+    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
       import effectie.instances.future.fxCtor._
       import loggerf.instances.future.logFuture
       runLog[Future](eab)
@@ -544,7 +544,7 @@ object extraSyntaxSpec extends Properties {
     implicit val ec: ExecutionContext =
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor500Millis) {
+    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
       import effectie.instances.future.fxCtor._
       import loggerf.instances.future.logFuture
       runLog[Future](eab)
@@ -593,7 +593,7 @@ object extraSyntaxSpec extends Properties {
     implicit val ec: ExecutionContext =
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor500Millis) {
+    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
       import effectie.instances.future.fxCtor._
       import loggerf.instances.future.logFuture
       runLog[Future](eab)
@@ -642,7 +642,7 @@ object extraSyntaxSpec extends Properties {
     implicit val ec: ExecutionContext =
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor500Millis) {
+    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
       import effectie.instances.future.fxCtor._
       import loggerf.instances.future.logFuture
       runLog[Future](eab)
@@ -688,7 +688,7 @@ object extraSyntaxSpec extends Properties {
     implicit val ec: ExecutionContext =
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor500Millis) {
+    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
       import effectie.instances.future.fxCtor._
       import loggerf.instances.future.logFuture
       runLog[Future](logMsg)
@@ -733,7 +733,7 @@ object extraSyntaxSpec extends Properties {
     implicit val ec: ExecutionContext =
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor500Millis) {
+    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
       import effectie.instances.future.fxCtor._
       import loggerf.instances.future.logFuture
       runLog[Future](logMsg)
@@ -779,7 +779,7 @@ object extraSyntaxSpec extends Properties {
     implicit val ec: ExecutionContext =
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor500Millis) {
+    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
       import effectie.instances.future.fxCtor._
       import loggerf.instances.future.logFuture
       runLog[Future](logMsg)
@@ -828,7 +828,7 @@ object extraSyntaxSpec extends Properties {
     implicit val ec: ExecutionContext =
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor500Millis) {
+    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
       import effectie.instances.future.fxCtor._
       import loggerf.instances.future.logFuture
       runLog[Future](eab)
@@ -877,7 +877,7 @@ object extraSyntaxSpec extends Properties {
     implicit val ec: ExecutionContext =
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor500Millis) {
+    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
       import effectie.instances.future.fxCtor._
       import loggerf.instances.future.logFuture
       runLog[Future](eab)
@@ -926,7 +926,7 @@ object extraSyntaxSpec extends Properties {
     implicit val ec: ExecutionContext =
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor500Millis) {
+    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
       import effectie.instances.future.fxCtor._
       import loggerf.instances.future.logFuture
       runLog[Future](eab)
@@ -975,7 +975,7 @@ object extraSyntaxSpec extends Properties {
     implicit val ec: ExecutionContext =
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor500Millis) {
+    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
       import effectie.instances.future.fxCtor._
       import loggerf.instances.future.logFuture
       runLog[Future](eab)
@@ -1024,7 +1024,7 @@ object extraSyntaxSpec extends Properties {
     implicit val ec: ExecutionContext =
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor500Millis) {
+    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
       import effectie.instances.future.fxCtor._
       import loggerf.instances.future.logFuture
       runLog[Future](eab)
@@ -1066,7 +1066,7 @@ object extraSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor500Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import loggerf.instances.future.logFuture
         runLog[Future]
       }
@@ -1103,7 +1103,7 @@ object extraSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor500Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import loggerf.instances.future.logFuture
         runLog[Future]
       }
@@ -1140,7 +1140,7 @@ object extraSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor500Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
         import loggerf.instances.future.logFuture
         runLog[Future]
@@ -1187,7 +1187,7 @@ object extraSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor500Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
         import loggerf.instances.future.logFuture
         runLog[Future](logMsg)
@@ -1233,7 +1233,7 @@ object extraSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor500Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
         import loggerf.instances.future.logFuture
         runLog[Future](logMsg)
@@ -1280,7 +1280,7 @@ object extraSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor500Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
         import loggerf.instances.future.logFuture
         runLog[Future](logMsg)
@@ -1329,7 +1329,7 @@ object extraSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor500Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
         import loggerf.instances.future.logFuture
         runLog[Future](eab)
@@ -1378,7 +1378,7 @@ object extraSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor500Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
         import loggerf.instances.future.logFuture
         runLog[Future](eab)
@@ -1427,7 +1427,7 @@ object extraSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor500Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
         import loggerf.instances.future.logFuture
         runLog[Future](eab)
@@ -1476,7 +1476,7 @@ object extraSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor500Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
         import loggerf.instances.future.logFuture
         runLog[Future](eab)
@@ -1525,7 +1525,7 @@ object extraSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor500Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
         import loggerf.instances.future.logFuture
         runLog[Future](eab)
@@ -1571,7 +1571,7 @@ object extraSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor500Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
         import loggerf.instances.future.logFuture
         runLog[Future](logMsg)
@@ -1616,7 +1616,7 @@ object extraSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor500Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
         import loggerf.instances.future.logFuture
         runLog[Future](logMsg)
@@ -1662,7 +1662,7 @@ object extraSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor500Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
         import loggerf.instances.future.logFuture
         runLog[Future](logMsg)
@@ -1711,7 +1711,7 @@ object extraSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor500Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
         import loggerf.instances.future.logFuture
         runLog[Future](eab)
@@ -1760,7 +1760,7 @@ object extraSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor500Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
         import loggerf.instances.future.logFuture
         runLog[Future](eab)
@@ -1809,7 +1809,7 @@ object extraSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor500Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
         import loggerf.instances.future.logFuture
         runLog[Future](eab)
@@ -1858,7 +1858,7 @@ object extraSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor500Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
         import loggerf.instances.future.logFuture
         runLog[Future](eab)
@@ -1907,7 +1907,7 @@ object extraSyntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor500Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import effectie.instances.future.fxCtor._
         import loggerf.instances.future.logFuture
         runLog[Future](eab)

--- a/modules/logger-f-core/jvm/src/test/scala/loggerf/instances/syntaxSpec.scala
+++ b/modules/logger-f-core/jvm/src/test/scala/loggerf/instances/syntaxSpec.scala
@@ -80,7 +80,7 @@ object syntaxSpec extends Properties {
 
   implicit val errorLogger: ErrorLogger[Throwable] = ErrorLogger.printlnDefaultErrorLogger
 
-  private val waitFor300Millis = WaitFor(400.milliseconds)
+  private val waitForXMillis = WaitFor(500.milliseconds)
 
   def testLogFA: Property = for {
     debugMsg <- Gen.string(Gen.unicode, Range.linear(1, 20)).log("debugMsg")
@@ -114,7 +114,7 @@ object syntaxSpec extends Properties {
     implicit val ec: ExecutionContext =
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-    ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+    ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
       import loggerf.instances.future.logFuture
       runLog[Future]
     }
@@ -153,7 +153,7 @@ object syntaxSpec extends Properties {
     implicit val ec: ExecutionContext =
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-    ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+    ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
       import loggerf.instances.future.logFuture
       runLog[Future]
     }
@@ -214,7 +214,7 @@ object syntaxSpec extends Properties {
     implicit val ec: ExecutionContext =
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-    ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+    ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
       import loggerf.instances.future.logFuture
       runLog[Future]
     }
@@ -252,7 +252,7 @@ object syntaxSpec extends Properties {
     implicit val ec: ExecutionContext =
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-    ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+    ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
       import loggerf.instances.future.logFuture
       runLog[Future]
     }
@@ -291,7 +291,7 @@ object syntaxSpec extends Properties {
     implicit val ec: ExecutionContext =
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-    ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+    ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
       import loggerf.instances.future.logFuture
       runLog[Future]
     }
@@ -358,7 +358,7 @@ object syntaxSpec extends Properties {
     implicit val ec: ExecutionContext =
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-    ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+    ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
       import loggerf.instances.future.logFuture
       runLog[Future]
     }
@@ -395,7 +395,7 @@ object syntaxSpec extends Properties {
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
     val expected = (debugMsg, infoMsg, warnMsg, errorMsg)
-    val actual   = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+    val actual   = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
       import loggerf.instances.future.logFuture
       runLog[Future]
     }
@@ -435,7 +435,7 @@ object syntaxSpec extends Properties {
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
     val expected = (debugMsg, infoMsg, warnMsg, errorMsg)
-    val actual   = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+    val actual   = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
       import loggerf.instances.future.logFuture
       runLog[Future]
     }
@@ -473,7 +473,7 @@ object syntaxSpec extends Properties {
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
     val expected = ((), (), (), ())
-    val actual   = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+    val actual   = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
       import loggerf.instances.future.logFuture
       runLog[Future]
     }
@@ -513,7 +513,7 @@ object syntaxSpec extends Properties {
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
     val expected = ((), (), (), ())
-    val actual   = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+    val actual   = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
       import loggerf.instances.future.logFuture
       runLog[Future]
     }
@@ -558,7 +558,7 @@ object syntaxSpec extends Properties {
     implicit val ec: ExecutionContext =
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
       import loggerf.instances.future.logFuture
       runLog[Future](logMsg)
     }
@@ -606,7 +606,7 @@ object syntaxSpec extends Properties {
     implicit val ec: ExecutionContext =
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
       import loggerf.instances.future.logFuture
       runLog[Future](logMsg)
     }
@@ -650,7 +650,7 @@ object syntaxSpec extends Properties {
     implicit val ec: ExecutionContext =
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
       import loggerf.instances.future.logFuture
       runLog[Future](logMsg)
     }
@@ -695,7 +695,7 @@ object syntaxSpec extends Properties {
     implicit val ec: ExecutionContext =
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
       import loggerf.instances.future.logFuture
       runLog[Future](logMsg)
     }
@@ -738,7 +738,7 @@ object syntaxSpec extends Properties {
     implicit val ec: ExecutionContext =
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-    ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+    ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
       import loggerf.instances.future.logFuture
       runLog[Future](logMsg)
     }
@@ -784,7 +784,7 @@ object syntaxSpec extends Properties {
     implicit val ec: ExecutionContext =
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-    ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+    ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
       import loggerf.instances.future.logFuture
       runLog[Future](logMsg)
     }
@@ -826,7 +826,7 @@ object syntaxSpec extends Properties {
     implicit val ec: ExecutionContext =
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-    ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+    ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
       import loggerf.instances.future.logFuture
       runLog[Future](logMsg)
     }
@@ -869,7 +869,7 @@ object syntaxSpec extends Properties {
     implicit val ec: ExecutionContext =
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-    ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+    ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
       import loggerf.instances.future.logFuture
       runLog[Future](logMsg)
     }
@@ -916,7 +916,7 @@ object syntaxSpec extends Properties {
     implicit val ec: ExecutionContext =
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
       import loggerf.instances.future.logFuture
       runLog[Future](eab)
     }
@@ -978,7 +978,7 @@ object syntaxSpec extends Properties {
     implicit val ec: ExecutionContext =
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
       import loggerf.instances.future.logFuture
       runLog[Future](eab)
     }
@@ -1025,7 +1025,7 @@ object syntaxSpec extends Properties {
     implicit val ec: ExecutionContext =
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
       import loggerf.instances.future.logFuture
       runLog[Future](eab)
     }
@@ -1072,7 +1072,7 @@ object syntaxSpec extends Properties {
     implicit val ec: ExecutionContext =
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+    val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
       import loggerf.instances.future.logFuture
       runLog[Future](eab)
     }
@@ -1118,7 +1118,7 @@ object syntaxSpec extends Properties {
     implicit val ec: ExecutionContext =
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-    ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+    ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
       import loggerf.instances.future.logFuture
       runLog[Future](eab)
     }
@@ -1185,7 +1185,7 @@ object syntaxSpec extends Properties {
     implicit val ec: ExecutionContext =
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-    ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+    ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
       import loggerf.instances.future.logFuture
       runLog[Future](eab)
     }
@@ -1231,7 +1231,7 @@ object syntaxSpec extends Properties {
     implicit val ec: ExecutionContext =
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-    ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+    ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
       import loggerf.instances.future.logFuture
       runLog[Future](eab)
     }
@@ -1277,7 +1277,7 @@ object syntaxSpec extends Properties {
     implicit val ec: ExecutionContext =
       ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-    ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+    ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
       import loggerf.instances.future.logFuture
       runLog[Future](eab)
     }
@@ -1321,7 +1321,7 @@ object syntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import loggerf.instances.future.logFuture
         runLog[Future]
       }
@@ -1417,7 +1417,7 @@ object syntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import loggerf.instances.future.logFuture
         runLog[Future]
       }
@@ -1478,7 +1478,7 @@ object syntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import loggerf.instances.future.logFuture
         runLog[Future]
       }
@@ -1519,7 +1519,7 @@ object syntaxSpec extends Properties {
         implicit val ec: ExecutionContext =
           ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-        ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+        ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
           import loggerf.instances.future.logFuture
           runLog[Future]
         }
@@ -1559,7 +1559,7 @@ object syntaxSpec extends Properties {
         implicit val ec: ExecutionContext =
           ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-        ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+        ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
           import loggerf.instances.future.logFuture
           runLog[Future]
         }
@@ -1625,7 +1625,7 @@ object syntaxSpec extends Properties {
         implicit val ec: ExecutionContext =
           ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-        ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+        ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
           import loggerf.instances.future.logFuture
           runLog[Future]
         }
@@ -1662,7 +1662,7 @@ object syntaxSpec extends Properties {
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
       val expected = (debugMsg, infoMsg, warnMsg, errorMsg)
-      val actual   = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val actual   = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import loggerf.instances.future.logFuture
         runLog[Future]
       }
@@ -1702,7 +1702,7 @@ object syntaxSpec extends Properties {
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
       val expected = (debugMsg, infoMsg, warnMsg, errorMsg)
-      val actual   = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val actual   = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import loggerf.instances.future.logFuture
         runLog[Future]
       }
@@ -1740,7 +1740,7 @@ object syntaxSpec extends Properties {
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
       val expected = ((), (), (), ())
-      val actual   = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val actual   = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import loggerf.instances.future.logFuture
         runLog[Future]
       }
@@ -1780,7 +1780,7 @@ object syntaxSpec extends Properties {
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
       val expected = ((), (), (), ())
-      val actual   = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val actual   = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import loggerf.instances.future.logFuture
         runLog[Future]
       }
@@ -1826,7 +1826,7 @@ object syntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import loggerf.instances.future.logFuture
         runLog[Future](logMsg)
       }
@@ -1874,7 +1874,7 @@ object syntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import loggerf.instances.future.logFuture
         runLog[Future](logMsg)
       }
@@ -1918,7 +1918,7 @@ object syntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import loggerf.instances.future.logFuture
         runLog[Future](logMsg)
       }
@@ -1963,7 +1963,7 @@ object syntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import loggerf.instances.future.logFuture
         runLog[Future](logMsg)
       }
@@ -2008,7 +2008,7 @@ object syntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import loggerf.instances.future.logFuture
         runLog[Future](logMsg)
       }
@@ -2056,7 +2056,7 @@ object syntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import loggerf.instances.future.logFuture
         runLog[Future](logMsg)
       }
@@ -2100,7 +2100,7 @@ object syntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import loggerf.instances.future.logFuture
         runLog[Future](logMsg)
       }
@@ -2145,7 +2145,7 @@ object syntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import loggerf.instances.future.logFuture
         runLog[Future](logMsg)
       }
@@ -2192,7 +2192,7 @@ object syntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import loggerf.instances.future.logFuture
         runLog[Future](eab)
       }
@@ -2251,7 +2251,7 @@ object syntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import loggerf.instances.future.logFuture
         runLog[Future](eab)
       }
@@ -2298,7 +2298,7 @@ object syntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import loggerf.instances.future.logFuture
         runLog[Future](eab)
       }
@@ -2345,7 +2345,7 @@ object syntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      val _ = ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import loggerf.instances.future.logFuture
         runLog[Future](eab)
       }
@@ -2393,7 +2393,7 @@ object syntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import loggerf.instances.future.logFuture
         runLog[Future](eab)
       }
@@ -2456,7 +2456,7 @@ object syntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import loggerf.instances.future.logFuture
         runLog[Future](eab)
       }
@@ -2504,7 +2504,7 @@ object syntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import loggerf.instances.future.logFuture
         runLog[Future](eab)
       }
@@ -2552,7 +2552,7 @@ object syntaxSpec extends Properties {
       implicit val ec: ExecutionContext =
         ConcurrentSupport.newExecutionContextWithLogger(es, ErrorLogger.printlnExecutionContextErrorLogger)
 
-      ConcurrentSupport.futureToValueAndTerminate(es, waitFor300Millis) {
+      ConcurrentSupport.futureToValueAndTerminate(es, waitForXMillis) {
         import loggerf.instances.future.logFuture
         runLog[Future](eab)
       }


### PR DESCRIPTION
## Update `extras` to `0.54.0` and increase async test timeouts

- `extras`: `0.53.0` => `0.54.0`

In `extraSyntaxSpec` and `syntaxSpec`, rename the `waitFor500Millis` and `waitFor300Millis` to `waitForXMillis`, and bump the `WaitFor` timeout from `500.milliseconds` to `600.milliseconds` and `400.milliseconds` to `500.milliseconds` respectively in order to reduce flakiness in the `Future`-based async tests.
