### PR TITLE
logger-f v2.11.0

### DIFF
--- a/changelogs/2.11.0.md
+++ b/changelogs/2.11.0.md
@@ -1,0 +1,21 @@
+## [2.11.0](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Av2-m6) - 2026-06-28
+
+## Changed
+
+* [`logger-f-sbt-logging`] Remove it from `logger-f` (#687)
+
+  Since `util-logging`, built for Scala 3, requires Scala `3.8.4`, it's hard to keep `logger-f-sbt-logging` in `logger-f` as Scala 3 version for `logger-f` is `3.3.x` (LTS).
+
+  So, `logger-f-sbt-logging` has been moved to [kevin-lee/logger-f-sbt-logging](/kevin-lee/logger-f-sbt-logging), and `logger-f-sbt-logging` module here should be removed.
+
+## Internal Housekeeping
+
+### Upgrade Scala 2.13 and libraries (#689)
+
+- `scala`: `2.13.17` => `2.13.18`
+- `effectie`: `2.3.0` => `2.4.0`
+- `cats-effect`: `3.3.14` => `3.7.0`
+- `cats-effect` (Native): `3.7.0-RC1` => `3.7.0`
+- `extras`: `0.49.0` => `0.53.0`
+
+### Update `doobie` 1 from `1.0.0-RC11` to `1.0.0-RC12` (#691)


### PR DESCRIPTION
# logger-f v2.11.0
## [2.11.0](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Av2-m6) - 2026-06-28

## Changed

* [`logger-f-sbt-logging`] Remove it from `logger-f` (#687)

  Since `util-logging`, built for Scala 3, requires Scala `3.8.4`, it's hard to keep `logger-f-sbt-logging` in `logger-f` as Scala 3 version for `logger-f` is `3.3.x` (LTS).

  So, `logger-f-sbt-logging` has been moved to [kevin-lee/logger-f-sbt-logging](/kevin-lee/logger-f-sbt-logging), and `logger-f-sbt-logging` module here should be removed.

## Internal Housekeeping

### Upgrade Scala 2.13 and libraries (#689)

- `scala`: `2.13.17` => `2.13.18`
- `effectie`: `2.3.0` => `2.4.0`
- `cats-effect`: `3.3.14` => `3.7.0`
- `cats-effect` (Native): `3.7.0-RC1` => `3.7.0`
- `extras`: `0.49.0` => `0.53.0`

### Update `doobie` 1 from `1.0.0-RC11` to `1.0.0-RC12` (#691)
