### PR TITLE
logger-f v2.12.0

### DIFF
--- a/changelogs/2.12.0.md
+++ b/changelogs/2.12.0.md
@@ -1,0 +1,8 @@
+## [2.12.0](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Av2-m7) - 2026-07-01
+
+
+## Internal Housekeeping
+
+### [`logger-f-doobie1`] Update `doobie` `1` from `1.0.0-RC12` to `1.0.0-RC13` (#695)
+
+This release has breaking changes due to [doobie 1.0.0-RC13](https://github.com/typelevel/doobie/releases/tag/v1.0.0-RC13).


### PR DESCRIPTION
# logger-f v2.12.0
## [2.12.0](https://github.com/Kevin-Lee/logger-f/issues?q=is%3Aissue%20is%3Aclosed%20milestone%3Av2-m7) - 2026-07-01


## Internal Housekeeping

### [`logger-f-doobie1`] Update `doobie` `1` from `1.0.0-RC12` to `1.0.0-RC13` (#695)

This release has breaking changes due to [doobie 1.0.0-RC13](https://github.com/typelevel/doobie/releases/tag/v1.0.0-RC13).
